### PR TITLE
Corrigido o erro da UI preta.

### DIFF
--- a/code/defines/procs/admin.dm
+++ b/code/defines/procs/admin.dm
@@ -55,4 +55,51 @@
 /proc/admin_log_and_message_admins(var/message as text)
 	log_admin("[key_name(usr)] " + message)
 	message_admins("[key_name_admin(usr)] " + message, 1)
-	
+
+/proc/replace_special_characters(var/text as text)
+	text = replacetext(text, "Ç", "C")
+	text = replacetext(text, "ç", "c")
+
+	text = replacetext(text, "Á", "A")
+	text = replacetext(text, "á", "a")
+	text = replacetext(text, "À", "A")
+	text = replacetext(text, "à", "a")
+	text = replacetext(text, "ã", "a")
+	text = replacetext(text, "Ã", "A")
+	text = replacetext(text, "â", "a")
+	text = replacetext(text, "Â", "A")
+
+	text = replacetext(text, "é", "e")
+	text = replacetext(text, "É", "E")
+	text = replacetext(text, "é", "e")
+	text = replacetext(text, "è", "e")
+	text = replacetext(text, "È", "E")
+	text = replacetext(text, "ê", "e")
+	text = replacetext(text, "Ê", "E")
+
+	text = replacetext(text, "í", "i")
+	text = replacetext(text, "Í", "I")
+	text = replacetext(text, "ì", "i")
+	text = replacetext(text, "Ì", "I")
+	text = replacetext(text, "î", "i")
+	text = replacetext(text, "Î", "I")
+
+	text = replacetext(text, "ó", "o")
+	text = replacetext(text, "Ó", "O")
+	text = replacetext(text, "ò", "o")
+	text = replacetext(text, "Ò", "O")
+	text = replacetext(text, "õ", "o")
+	text = replacetext(text, "Õ", "O")
+	text = replacetext(text, "ô", "o")
+	text = replacetext(text, "Ô", "O")
+
+	text = replacetext(text, "ú", "u")
+	text = replacetext(text, "Ú", "U")
+	text = replacetext(text, "ù", "u")
+	text = replacetext(text, "Ù", "U")
+	text = replacetext(text, "û", "u")
+	text = replacetext(text, "Û", "U")
+
+	text = replacetext(text, "ñ", "n")
+	text = replacetext(text, "Ñ", "N")
+	return text

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -307,6 +307,7 @@ var/time_last_changed_position = 0
 				var/t1 = href_list["assign_target"]
 				if(t1 == "Custom")
 					var/temp_t = sanitize(copytext(input("Enter a custom job assignment.","Assignment"),1,MAX_MESSAGE_LEN))
+					temp_t = replace_special_characters(temp_t)
 					//let custom jobs function as an impromptu alt title, mainly for sechuds
 					if(temp_t && modify)
 						modify.assignment = temp_t

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -205,11 +205,15 @@
 			setMenuState(usr,COMM_SCREEN_STAT)
 
 		if("setmsg1")
-			stat_msg1 = input("Line 1", "Enter Message Text", stat_msg1) as text|null
+			var/input = input("Line 1", "Enter Message Text", stat_msg1)
+			input = replace_special_characters(input)
+			stat_msg1 = input
 			setMenuState(usr,COMM_SCREEN_STAT)
 
 		if("setmsg2")
-			stat_msg2 = input("Line 2", "Enter Message Text", stat_msg2) as text|null
+			var/input = input("Line 2", "Enter Message Text", stat_msg2)
+			input = replace_special_characters(input)
+			stat_msg2 = input
 			setMenuState(usr,COMM_SCREEN_STAT)
 
 		if("nukerequest")

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -439,6 +439,7 @@
 					//Select Your Name
 					if("Sender")
 						customsender 	= input(usr, "Please enter the sender's name.") as text|null
+						customsender = replace_special_characters(customsender)
 
 					//Select Receiver
 					if("Recepient")
@@ -458,11 +459,13 @@
 					//Enter custom job
 					if("RecJob")
 						customjob	 	= input(usr, "Please enter the sender's job.") as text|null
+						customjob = replace_special_characters(customjob)
 
 					//Enter message
 					if("Message")
 						custommessage	= input(usr, "Please enter your message.") as text|null
 						custommessage	= sanitize(copytext(custommessage, 1, MAX_MESSAGE_LEN))
+						custommessage = replace_special_characters(custommessage)
 
 					//Send message
 					if("Send")

--- a/code/modules/pda/messenger.dm
+++ b/code/modules/pda/messenger.dm
@@ -119,6 +119,7 @@
 
 /datum/data/pda/app/messenger/proc/create_message(var/mob/living/U, var/obj/item/device/pda/P)
 	var/t = input(U, "Please enter message", name, null) as text|null
+	t = replace_special_characters(t)
 	if(!t)
 		return
 	t = sanitize(copytext(t, 1, MAX_MESSAGE_LEN))

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -506,6 +506,7 @@
 
 		var/timeout = world.time + 600
 		var/reason = input(usr,"Reason:","Why do you require this item?","") as null|text
+		reason = replace_special_characters(reason)
 		if(world.time > timeout || !reason || ..())
 			return 1
 		reason = sanitize(copytext(reason, 1, MAX_MESSAGE_LEN))
@@ -680,6 +681,7 @@
 
 		var/timeout = world.time + 600
 		var/reason = input(usr,"Reason:","Why do you require this item?","") as null|text
+		reason = replace_special_characters(reason)
 		if(world.time > timeout || !reason || !is_authorized(usr) || ..())
 			return 1
 		reason = sanitize(copytext(reason, 1, MAX_MESSAGE_LEN))


### PR DESCRIPTION
Adicionado o proc "replace_special_characters" que substitui carácteres especiais pelos equivalentes. Exemplo: Ç por C, Ã por A. Com isso, o erro da UI ficar preta é corrigido. (Só coloquei esse proc em consoles muito usados, como o Supply, PDA, Communications, ID Console, etc.