### PR TITLE
RND Console fix.

### DIFF
--- a/nano/templates/r_n_d.tmpl
+++ b/nano/templates/r_n_d.tmpl
@@ -1,4 +1,4 @@
-{{if data.menu > 0 && !data.wait_message}}
+{{if data.menu > 0}}
 	<div class='item'>
 		{{:helper.link('Main Menu', 'reply', {'menu': 0, 'submenu': 0})}}
 		{{if data.submenu > 0}}
@@ -18,16 +18,19 @@
 	</div>
 {{/if}}
 <div class='statusDisplay'>
-	{{if data.wait_message}}
-		{{:data.wait_message}}
-	{{else data.menu == 0}}
+	{{if data.menu == 0}}
 		<h3>Main Menu:</h3>
-		<div class='line'>{{:helper.link('Current Research Levels', 'folder-open', {'menu': 1, 'submenu': 0})}}</div>
 		<div class='line'>{{:helper.link('Disk Operations', 'save', {'menu': 2, 'submenu': 0}, data.disk_type ? null : 'disabled')}}</div>
 		<div class='line'>{{:helper.link('Destructive Analyzer Menu', 'chain-broken', {'menu': 3, 'submenu': 0}, data.linked_destroy ? null : 'disabled')}}</div>
 		<div class='line'>{{:helper.link('Protolathe Menu', 'print', {'menu': 4, 'submenu': 0}, data.linked_lathe ? null : 'disabled')}}</div>
 		<div class='line'>{{:helper.link('Circuit Imprinter Menu', 'print', {'menu': 5, 'submenu': 0}, data.linked_imprinter ? null : 'disabled')}}</div>
 		<div class='line'>{{:helper.link('Settings', 'gear', {'menu': 6, 'submenu': 0})}}</div>
+		<br>
+		<br>
+		Current Research Levels:
+		{{for data.tech_levels}}
+		<div class='line'><div class='itemLabel'>{{:value.name}}:</div>{{:value.level}}</div>
+		{{/for}}
 	{{else data.menu == 1}}
 		<h3>Current Research Levels:</h3>
 		{{for data.tech_levels}}
@@ -258,3 +261,11 @@
 		{{/if}}
 	{{/if}}
 </div>
+
+{{if data.wait_message}}
+	<div class="mask">
+		<div class="maskContent">
+			<h1>{{:data.wait_message}}</h1>
+		</div>
+	</div>
+{{/if}}


### PR DESCRIPTION
Antes:

![Antes](https://cloud.githubusercontent.com/assets/10916307/17089920/7e172314-51f9-11e6-9906-9ad180075196.gif)

Depois:

![Depois](https://cloud.githubusercontent.com/assets/10916307/17089948/b42812c4-51f9-11e6-8427-3ed6a809c226.gif)

Perceba que a antes a tela subia depois da construção de algo, atrapalhando quem quer fazer várias coisas seguidas.