### PR TITLE
Blood refactor.

### DIFF
--- a/code/__DEFINES/genetics.dm
+++ b/code/__DEFINES/genetics.dm
@@ -121,6 +121,13 @@
 #define NUTRITION_LEVEL_HUNGRY 250
 #define NUTRITION_LEVEL_STARVING 150
 
+//Blood levels
+#define BLOOD_VOLUME_NORMAL			560
+#define BLOOD_VOLUME_SAFE			501
+#define BLOOD_VOLUME_OKAY			336
+#define BLOOD_VOLUME_BAD			224
+#define BLOOD_VOLUME_SURVIVE		122
+
 //Used for calculations for negative effects of having genetics powers
 #define DEFAULT_GENE_STABILITY 100
 #define GENE_INSTABILITY_MINOR 5

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -172,11 +172,12 @@
 		// I'm not sure WHY you'd want to put a simple_animal in a sleeper, but precedent is precedent
 		// Runtime is aptly named, isn't she?
 		if (ishuman(occupant) && occupant.vessel && !(occupant.species && occupant.species.flags & NO_BLOOD))
+			var/blood_type = occupant.get_blood_name()
 			occupantData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
 			occupantData["hasBlood"] = 1
-			occupantData["bloodLevel"] = round(occupant.vessel.get_reagent_amount("blood"))
+			occupantData["bloodLevel"] = round(occupant.vessel.get_reagent_amount(blood_type))
 			occupantData["bloodMax"] = occupant.max_blood
-			occupantData["bloodPercent"] = round(100*(occupant.vessel.get_reagent_amount("blood")/occupant.max_blood), 0.01)
+			occupantData["bloodPercent"] = round(100*(occupant.vessel.get_reagent_amount(blood_type)/occupant.max_blood), 0.01)
 
 	data["occupant"] = occupantData
 	data["maxchem"] = connected.max_chem

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -357,12 +357,13 @@
 			var/bloodData[0]
 			bloodData["hasBlood"] = 0
 			if(ishuman(H) && H.vessel && !(H.species && H.species.flags & NO_BLOOD))
-				var/blood_volume = round(H.vessel.get_reagent_amount("blood"))
+				var/blood_type = H.get_blood_name()
+				var/blood_volume = round(H.vessel.get_reagent_amount(blood_type))
 				bloodData["hasBlood"] = 1
 				bloodData["volume"] = blood_volume
-				bloodData["percent"] = round(((blood_volume / 560)*100))
+				bloodData["percent"] = round(((blood_volume / BLOOD_VOLUME_NORMAL)*100))
 				bloodData["pulse"] = H.get_pulse(GETPULSE_TOOL)
-				bloodData["bloodLevel"] = round(H.vessel.get_reagent_amount("blood"))
+				bloodData["bloodLevel"] = blood_volume
 				bloodData["bloodMax"] = H.max_blood
 			occupantData["blood"] = bloodData
 
@@ -530,9 +531,9 @@
 				dat += "Large growth detected in frontal lobe, possibly cancerous. Surgical removal is recommended.<br>"
 
 			if(occupant.vessel)
-				var/blood_volume = round(occupant.vessel.get_reagent_amount("blood"))
-				var/blood_percent =  blood_volume / 560
-				blood_percent *= 100
+				var/blood_type = occupant.get_blood_name()
+				var/blood_volume = round(occupant.vessel.get_reagent_amount(blood_type))
+				var/blood_percent =  blood_volume / BLOOD_VOLUME_NORMAL
 
 				extra_font = (blood_volume > 448 ? "<font color='blue'>" : "<font color='red'>")
 				dat += "[extra_font]\tBlood Level %: [blood_percent] ([blood_volume] units)</font><br>"

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -132,11 +132,12 @@
 		occupantData["btFaren"] = ((occupant.bodytemperature - T0C) * (9.0/5.0))+ 32
 
 		if (ishuman(occupant) && occupant.vessel && !(occupant.species && occupant.species.flags & NO_BLOOD))
+			var/blood_type = occupant.get_blood_name()
 			occupantData["pulse"] = occupant.get_pulse(GETPULSE_TOOL)
 			occupantData["hasBlood"] = 1
-			occupantData["bloodLevel"] = round(occupant.vessel.get_reagent_amount("blood"))
+			occupantData["bloodLevel"] = round(occupant.vessel.get_reagent_amount(blood_type))
 			occupantData["bloodMax"] = occupant.max_blood
-			occupantData["bloodPercent"] = round(100*(occupant.vessel.get_reagent_amount("blood")/occupant.max_blood), 0.01) //copy pasta ends here
+			occupantData["bloodPercent"] = round(100*(occupant.vessel.get_reagent_amount(blood_type)/occupant.max_blood), 0.01) //copy pasta ends here
 
 			occupantData["bloodType"]=occupant.b_type
 		if(occupant.surgeries.len)

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -227,15 +227,19 @@ REAGENT SCANNER
 				user.show_message(text("\red Internal bleeding detected. Advanced scanner required for location."), 1)
 				break
 		if(H.vessel)
-			var/blood_volume = round(M:vessel.get_reagent_amount("blood"))
-			var/blood_percent =  blood_volume / 560
+			var/blood_type = H.get_blood_name()
+			var/blood_volume = round(H.vessel.get_reagent_amount(blood_type))
+			var/blood_percent =  blood_volume / BLOOD_VOLUME_NORMAL
 			blood_percent *= 100
 			if(blood_volume <= 500)
-				user.show_message("\red <b>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl")
+				user.show_message("<span class='warning'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl</span>")
 			else if(blood_volume <= 336)
-				user.show_message("\red <b>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl")
+				user.show_message("<span class='warning'>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl</span>")
 			else
-				user.show_message("\blue Blood Level Normal: [blood_percent]% [blood_volume]cl")
+				user.show_message("<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl</span>")
+			if(H.species.exotic_blood)
+				user.show_message("<span class='warning'>Subject possesses exotic blood.</span>")
+				user.show_message("<span class='warning'>Exotic blood type: [blood_type].</span>")
 		if(H.heart_attack && H.stat != DEAD)
 			user.show_message("<span class='userdanger'>Subject suffering from heart attack: Apply defibrillator immediately.</span>")
 		user.show_message("\blue Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font>")

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -316,8 +316,9 @@ This function restores the subjects blood to max.
 */
 /mob/living/carbon/human/proc/restore_blood()
 	if(!(species.flags & NO_BLOOD))
-		var/blood_volume = vessel.get_reagent_amount("blood")
-		vessel.add_reagent("blood", 560.0 - blood_volume)
+		var/blood_type = get_blood_name()
+		var/blood_volume = vessel.get_reagent_amount(blood_type)
+		vessel.add_reagent(blood_type, BLOOD_VOLUME_NORMAL - blood_volume)
 
 /*
 This function restores all organs.

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -72,7 +72,7 @@ var/global/default_martial_art = new/datum/martial_art
 	var/mob/remoteview_target = null
 	var/meatleft = 3 //For chef item
 	var/decaylevel = 0 // For rotting bodies
-	var/max_blood = 560 // For stuff in the vessel
+	var/max_blood = BLOOD_VOLUME_NORMAL // For stuff in the vessel
 	var/slime_color = "blue" //For slime people this defines their color, it's blue by default to pay tribute to the old icons
 
 	var/check_mutations=0 // Check mutations on next life tick

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1066,7 +1066,8 @@
 
 	var/temp = PULSE_NORM
 
-	if(round(vessel.get_reagent_amount("blood")) <= BLOOD_VOLUME_BAD)	//how much blood do we have
+	var/blood_type = get_blood_name()
+	if(round(vessel.get_reagent_amount(blood_type)) <= BLOOD_VOLUME_BAD)	//how much blood do we have
 		temp = PULSE_THREADY	//not enough :(
 
 	if(status_flags & FAKEDEATH)

--- a/code/modules/reagents/newchem/medicine.dm
+++ b/code/modules/reagents/newchem/medicine.dm
@@ -4,7 +4,7 @@
 
 #define REM REAGENTS_EFFECT_MULTIPLIER
 
-datum/reagent/silver_sulfadiazine
+/datum/reagent/silver_sulfadiazine
 	name = "Silver Sulfadiazine"
 	id = "silver_sulfadiazine"
 	description = "This antibacterial compound is used to treat burn victims."
@@ -12,7 +12,7 @@ datum/reagent/silver_sulfadiazine
 	color = "#F0C814"
 	metabolization_rate = 3
 
-datum/reagent/silver_sulfadiazine/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
+/datum/reagent/silver_sulfadiazine/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
 	if(iscarbon(M))
 		if(method == TOUCH)
 			M.adjustFireLoss(-volume)
@@ -25,13 +25,13 @@ datum/reagent/silver_sulfadiazine/reaction_mob(var/mob/living/M as mob, var/meth
 	..()
 	return
 
-datum/reagent/silver_sulfadiazine/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/silver_sulfadiazine/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	M.adjustFireLoss(-2*REM)
 	..()
 	return
 
-datum/reagent/styptic_powder
+/datum/reagent/styptic_powder
 	name = "Styptic Powder"
 	id = "styptic_powder"
 	description = "Styptic (aluminium sulfate) powder helps control bleeding and heal physical wounds."
@@ -39,7 +39,7 @@ datum/reagent/styptic_powder
 	color = "#C8A5DC"
 	metabolization_rate = 3
 
-datum/reagent/styptic_powder/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
+/datum/reagent/styptic_powder/reaction_mob(var/mob/living/M as mob, var/method=TOUCH, var/volume, var/show_message = 1)
 	if(iscarbon(M))
 		if(method == TOUCH)
 			M.adjustBruteLoss(-volume)
@@ -53,13 +53,13 @@ datum/reagent/styptic_powder/reaction_mob(var/mob/living/M as mob, var/method=TO
 	..()
 	return
 
-datum/reagent/styptic_powder/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/styptic_powder/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	M.adjustBruteLoss(-2*REM)
 	..()
 	return
 
-datum/reagent/salglu_solution
+/datum/reagent/salglu_solution
 	name = "Saline-Glucose Solution"
 	id = "salglu_solution"
 	description = "This saline and glucose solution can help stabilize critically injured patients and cleanse wounds."
@@ -68,22 +68,26 @@ datum/reagent/salglu_solution
 	penetrates_skin = 1
 	metabolization_rate = 0.15
 
-datum/reagent/salglu_solution/on_mob_life(var/mob/living/M as mob)
-	if(!M) M = holder.my_atom
+/datum/reagent/salglu_solution/on_mob_life(mob/living/M)
+	if(!M)
+		M = holder.my_atom
 	if(prob(33))
 		M.adjustBruteLoss(-2*REM)
 		M.adjustFireLoss(-2*REM)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.species.exotic_blood && !(H.species.flags & NO_BLOOD) && prob(33))
+			H.vessel.add_reagent("blood", 1)
 	..()
-	return
 
-datum/reagent/synthflesh
+/datum/reagent/synthflesh
 	name = "Synthflesh"
 	id = "synthflesh"
 	description = "A resorbable microfibrillar collagen and protein mixture that can rapidly heal injuries when applied topically."
 	reagent_state = LIQUID
 	color = "#FFEBEB"
 
-datum/reagent/synthflesh/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume,var/show_message = 1)
+/datum/reagent/synthflesh/reaction_mob(var/mob/living/M, var/method=TOUCH, var/volume,var/show_message = 1)
 	if(!M) M = holder.my_atom
 	if(iscarbon(M))
 		if(method == TOUCH)
@@ -94,21 +98,21 @@ datum/reagent/synthflesh/reaction_mob(var/mob/living/M, var/method=TOUCH, var/vo
 	..()
 	return
 
-datum/reagent/synthflesh/reaction_turf(var/turf/T, var/volume) //let's make a mess!
+/datum/reagent/synthflesh/reaction_turf(var/turf/T, var/volume) //let's make a mess!
 	src = null
 	if(volume >= 5)
 		new /obj/effect/decal/cleanable/blood/gibs/cleangibs(T)
 		playsound(T, 'sound/effects/splat.ogg', 50, 1, -3)
 		return
 
-datum/reagent/charcoal
+/datum/reagent/charcoal
 	name = "Charcoal"
 	id = "charcoal"
 	description = "Activated charcoal helps to absorb toxins."
 	reagent_state = LIQUID
 	color = "#000000"
 
-datum/reagent/charcoal/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/charcoal/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	M.adjustToxLoss(-1.5*REM)
 	if(prob(50))
@@ -216,7 +220,7 @@ datum/reagent/omnizine
 			M.Dizzy(5)
 			M.Weaken(3)
 
-datum/reagent/calomel
+/datum/reagent/calomel
 	name = "Calomel"
 	id = "calomel"
 	description = "This potent purgative rids the body of impurities. It is highly toxic however and close supervision is required."
@@ -224,7 +228,7 @@ datum/reagent/calomel
 	color = "#22AB35"
 	metabolization_rate = 0.8
 
-datum/reagent/calomel/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/calomel/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		if(R != src)
@@ -245,14 +249,14 @@ datum/reagent/calomel/on_mob_life(var/mob/living/M as mob)
 	min_temp = 374
 	mix_message = "Stinging vapors rise from the solution."
 
-datum/reagent/potass_iodide
+/datum/reagent/potass_iodide
 	name = "Potassium Iodide"
 	id = "potass_iodide"
 	description = "Potassium Iodide is a medicinal drug used to counter the effects of radiation poisoning."
 	reagent_state = LIQUID
 	color = "#B4DCBE"
 
-datum/reagent/potass_iodide/on_mob_life(var/mob/living/M as mob)
+/datum/reagent/potass_iodide/on_mob_life(var/mob/living/M as mob)
 	if(!M) M = holder.my_atom
 	if(prob(80))
 		M.radiation = max(0, M.radiation-1)

--- a/code/modules/reagents/oldchem/reagents/reagents_food.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_food.dm
@@ -9,19 +9,25 @@
 	nutriment_factor = 12 * REAGENTS_METABOLISM
 	color = "#664330" // rgb: 102, 67, 48
 
-/datum/reagent/nutriment/on_mob_life(var/mob/living/M as mob)
-	if(!M) M = holder.my_atom
+/datum/reagent/nutriment/on_mob_life(mob/living/M)
+	if(!M)
+		M = holder.my_atom
 	if(!(M.mind in ticker.mode.vampires))
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if(H.can_eat())	//Make sure the species has it's dietflag set, otherwise it can't digest any nutrients
 				H.nutrition += nutriment_factor	// For hunger and fatness
-				if(prob(50)) M.adjustBruteLoss(-1)
+				if(prob(50))
+					M.adjustBruteLoss(-1)
+				if(H.species.exotic_blood)
+					H.vessel.add_reagent(H.species.exotic_blood, 0.4)
+				else
+					if(!(H.species.flags & NO_BLOOD))
+						H.vessel.add_reagent("blood", 0.4)
 		if(istype(M,/mob/living/simple_animal))		//Any nutrients can heal simple animals
-			if(prob(50)) M.heal_organ_damage(1,0)
+			if(prob(50))
+				M.heal_organ_damage(1,0)
 	..()
-	return
-
 
 /datum/reagent/protein			// Meat-based protein, digestable by carnivores and omnivores, worthless to herbivores
 	name = "Protein"

--- a/code/modules/reagents/oldchem/reagents/reagents_misc.dm
+++ b/code/modules/reagents/oldchem/reagents/reagents_misc.dm
@@ -164,6 +164,14 @@
 	return
 */
 
+/datum/reagent/iron/on_mob_life(mob/living/M)
+	if(!M)
+		M = holder.my_atom
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.species.exotic_blood && !(H.species.flags & NO_BLOOD))
+			H.vessel.add_reagent("blood", 0.8)
+	..()
 
 
 //foam

--- a/code/modules/surgery/organs/blood.dm
+++ b/code/modules/surgery/organs/blood.dm
@@ -2,13 +2,8 @@
 				BLOOD SYSTEM
 ****************************************************/
 //Blood levels
-var/const/BLOOD_VOLUME_SAFE = 501
-var/const/BLOOD_VOLUME_OKAY = 336
-var/const/BLOOD_VOLUME_BAD = 224
-var/const/BLOOD_VOLUME_SURVIVE = 122
 
 /mob/living/carbon/human/var/datum/reagents/vessel	//Container for blood and BLOOD ONLY. Do not transfer other chems here.
-/mob/living/carbon/human/var/var/pale = 0			//Should affect how mob sprite is drawn, but currently doesn't.
 
 //Initializes blood vessels
 /mob/living/carbon/human/proc/make_blood()
@@ -60,12 +55,8 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 			blood_volume = round(vessel.get_reagent_amount(blood_reagent))
 			if(blood_volume < max_blood && blood_volume)
 				vessel.add_reagent(blood_reagent, 0.1) // regenerate blood VERY slowly
-				if (reagents.has_reagent("nutriment"))	//Getting food speeds it up
+				if(reagents.has_reagent(blood_reagent))
 					vessel.add_reagent(blood_reagent, 0.4)
-					reagents.remove_reagent("nutriment", 0.1)
-				else if (reagents.has_reagent(blood_reagent))
-					vessel.add_reagent(blood_reagent, 0.4)
-					reagents.remove_reagent(blood_reagent, 0.4)
 
 		else
 			blood_volume = round(vessel.get_reagent_amount("blood"))
@@ -74,13 +65,13 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 				var/datum/reagent/blood/B = locate() in vessel.reagent_list //Grab some blood
 				if(B) // Make sure there's some blood at all
 
-					if(src.mind) //Handles vampires "eating" blood that isn't their own.
-						if(src.mind in ticker.mode.vampires)
+					if(mind) //Handles vampires "eating" blood that isn't their own.
+						if(mind in ticker.mode.vampires)
 							for(var/datum/reagent/blood/BL in vessel.reagent_list)
-								if(src.nutrition >= 450)
+								if(nutrition >= 450)
 									break //We don't want blood tranfusions making vampires fat.
 								if(BL.data["donor"] != src)
-									src.nutrition += (15 * REAGENTS_METABOLISM)
+									nutrition += (15 * REAGENTS_METABOLISM)
 									BL.volume -= REAGENTS_METABOLISM
 									if(BL.volume <= 0)
 										qdel(BL)
@@ -93,85 +84,47 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 								break
 
 					vessel.add_reagent("blood", 0.1) // regenerate blood VERY slowly
-					if (reagents.has_reagent("nutriment"))	//Getting food speeds it up
-						vessel.add_reagent("blood", 0.4)
-						reagents.remove_reagent("nutriment", 0.1)
-					if (reagents.has_reagent("iron"))	//Hematogen candy anyone?
-						vessel.add_reagent("blood", 0.8)
-						reagents.remove_reagent("iron", 0.1)
-					if (reagents.has_reagent("salglu_solution"))	//saline is good for blood regeneration
-						if(prob(33))
-							vessel.add_reagent("blood", 1.0)
-
-		// Damaged heart virtually reduces the blood volume, as the blood isn't
-		// being pumped properly anymore.
-		var/obj/item/organ/internal/heart/heart = get_int_organ(/obj/item/organ/internal/heart)
-
-		if(heart)
-			if(heart.damage > 1 && heart.damage < heart.min_bruised_damage)
-				blood_volume *= 0.8
-			else if(heart.damage >= heart.min_bruised_damage && heart.damage < heart.min_broken_damage)
-				blood_volume *= 0.6
-			else if(heart.damage >= heart.min_broken_damage && heart.damage < INFINITY)
-				blood_volume *= 0.3
 
 		//Effects of bloodloss
+		var/oxy_immune = species.flags & NO_BREATHE //Some species have blood, but don't breathe; they should still suffer the effects of bloodloss.
+
 		switch(blood_volume)
-			if(BLOOD_VOLUME_SAFE to 10000)
-				if(pale)
-					pale = 0
-					update_body()
 			if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
-				if(!pale)
-					pale = 1
-					update_body()
-					var/word = pick("dizzy","woosey","faint")
-					to_chat(src, "\red You feel [word]")
-				if(prob(1))
-					var/word = pick("dizzy","woosey","faint")
-					to_chat(src, "\red You feel [word]")
-				if(oxyloss < 20)
-					oxyloss += 3
+				if(prob(5))
+					to_chat(src, "<span class='warning'>You feel [pick("dizzy","woozy","faint")].</span>")
+				if(oxy_immune)
+					adjustToxLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.01, 1))
+				else
+					adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.01, 1))
 			if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
-				if(!pale)
-					pale = 1
-					update_body()
-				eye_blurry += 6
-				if(oxyloss < 50)
-					oxyloss += 10
-				oxyloss += 1
-				if(prob(15))
-					Paralyse(rand(1,3))
-					var/word = pick("dizzy","woosey","faint")
-					to_chat(src, "\red You feel very [word]")
+				if(oxy_immune)
+					adjustToxLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+				else
+					adjustOxyLoss(round((BLOOD_VOLUME_NORMAL - blood_volume) * 0.02, 1))
+				if(prob(5))
+					eye_blurry = max(eye_blurry, 6)
+					var/word = pick("dizzy","woozy","faint")
+					to_chat(src, "<span class='warning'>You feel very [word].</span>")
 			if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
-				if(!pale)
-					pale = 1
-					update_body()
-				if(oxyloss > 20)
-					eye_blurry += 6
-				oxyloss += 12
+				if(oxy_immune)
+					adjustToxLoss(5)
+				else
+					adjustOxyLoss(5)
 				if(prob(15))
 					Paralyse(rand(1,3))
-					var/word = pick("dizzy","woosey","faint")
-					to_chat(src, "\red You feel extremely [word]")
+					var/word = pick("dizzy","woozy","faint")
+					to_chat(src, "<span class='warning'>You feel extremely [word].</span>")
 			if(0 to BLOOD_VOLUME_SURVIVE)
 				death()
-
-		// Without enough blood you slowly go hungry.
-		if(blood_volume < BLOOD_VOLUME_SAFE)
-			if(nutrition >= 300)
-				nutrition -= 10
-			else if(nutrition >= 200)
-				nutrition -= 3
 
 		//Bleeding out
 		var/blood_max = 0
 		for(var/obj/item/organ/external/temp in organs)
 			if(!(temp.status & ORGAN_BLEEDING) || temp.status & ORGAN_ROBOT)
 				continue
-			for(var/datum/wound/W in temp.wounds) if(W.bleeding())
-				blood_max += W.damage / 4
+			for(var/datum/wound/W in temp.wounds)
+				if(W.bleeding())
+					blood_max += W.damage / 4
 			if (temp.open)
 				blood_max += 2  //Yer stomach is cut open
 		drip(blood_max)
@@ -188,7 +141,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	var/amm = 0.1 * amt
 	var/turf/T = get_turf(src)
 
-	if(src.species.exotic_blood)
+	if(species.exotic_blood)
 		vessel.remove_reagent(species.exotic_blood,amm)
 		if(vessel.total_volume)
 			var/fraction = amm / vessel.total_volume
@@ -197,7 +150,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 
 	else
 		vessel.remove_reagent("blood",amm)
-		blood_splatter(src,src)
+		blood_splatter(src, src)
 
 
 /****************************************************
@@ -269,7 +222,7 @@ var/const/BLOOD_VOLUME_SURVIVE = 122
 	var/list/chems = list()
 	chems = params2list(injected.data["trace_chem"])
 	for(var/C in chems)
-		src.reagents.add_reagent(C, (text2num(chems[C]) / 560) * amount)//adds trace chemicals to owner's blood
+		src.reagents.add_reagent(C, (text2num(chems[C]) / BLOOD_VOLUME_NORMAL) * amount)//adds trace chemicals to owner's blood
 	reagents.update_total()
 
 	container.reagents.remove_reagent("blood", amount)

--- a/html/changelogs/Davipatury-PR-81.yml
+++ b/html/changelogs/Davipatury-PR-81.yml
@@ -1,0 +1,42 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name. Remove the quotation mark and put in your name when copy+pasting the example changelog.
+author: Davipatury
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Oxygen damage number changed a bit; damage is based upon volume lost more now"
+  - tweak: "Species that have blood but are oxygen immune will now take tox damage"
+  - rscadd: "Health analyzers will now work with species with exotic blood and inform the user what type of exotic blood they have"
+  - rscadd: "Other machinery that display blood levels (op table, sleepers, advanced scanners, etc) will now work with exotic blood"
+  - bugfix: "Changeling regen will now properly restore blood if you have exotic blood"
+  - bugfix: "Fixes being blurry for 20+ minutes when you were low on blood for a mere 3 minutes"
+  - tweak: "Heart damage impacting blood volume removed"
+  - tweak: "Nutrition draining when low on blood removed"


### PR DESCRIPTION
### Gameplay changes

- Oxygen damage number changed a bit; damage is based upon volume lost more now
- Species that have blood but are oxygen immune will now take tox damage from being low on blood
- Heart damage impacting blood volume removed
  - Getting KO'd permanently after getting a pair of wirecutters jabbed into your chest because of RNG isn't really fun, fair, or balanced. This also helps bring ballistics back to the realm of sanity in terms of overall damage they do
- Nutrition draining when low on blood removed
  - Nutrition being low makes you super slow--being low on blood makes you already slow from having high damage levels--this is redundant.

### Fixes

- Fixes being blurry for 20+ minutes when you were low on blood for a mere 3 minutes
- Changeling regen will now properly restore blood if you have exotic blood
- Health analyzers will now work with species with exotic blood and inform the user what type of exotic blood they have
- Other medical machinery that display blood levels (op table, sleepers, advanced scanners, etc) will now work with exotic blood

### Code wise

- Blood volume levels are now defines instead of constants
- Moved as much of the blood restoration out of handle_blood into the reagents themselves
- Format/readability cleanup here and there