### PR TITLE
AI fixes

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -231,9 +231,8 @@ var/round_start_time = 0
 
 	votetimer()
 
-	for(var/mob/M in mob_list)
-		if(istype(M,/mob/new_player))
-			var/mob/new_player/N = M
+	for(var/mob/new_player/N in mob_list)
+		if(N.client)
 			N.new_player_panel_proc()
 
 	return 1

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -349,7 +349,8 @@ var/round_start_time = 0
 			if(player.ready && player.mind)
 				if(player.mind.assigned_role == "AI" || player.mind.special_role == "malfunctioning AI")
 					player.close_spawn_windows()
-					player.AIize()
+					var/mob/living/silicon/ai/ai_character = player.AIize()
+					ai_character.moveToAILandmark()
 				else if(!player.mind.assigned_role)
 					continue
 				else

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -203,7 +203,7 @@ var/bomb_set
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "nuclear_bomb.tmpl", "Nuke Control Panel", 450, 550)
+		ui = new(user, src, ui_key, "nuclear_bomb.tmpl", "Nuke Control Panel", 450, 550, state = physical_state)
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -264,9 +264,9 @@ atom/proc/transfer_ai(var/interaction, var/mob/user, var/mob/living/silicon/ai/A
 	if(interaction == AI_TRANS_FROM_CARD)
 		AI.control_disabled = 0
 		AI.aiRadio.disabledAi = 0
-		AI.loc = loc//To replace the terminal.
+		AI.forceMove(loc)//To replace the terminal.
 		to_chat(AI, "You have been uploaded to a stationary terminal. Remote device connection restored.")
-		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully. Local copy has been removed.")
+		to_chat(user, "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully. Local copy has been removed.</span>")
 		qdel(src)
 	else //If for some reason you use an empty card on an empty AI terminal.
 		to_chat(user, "There is no AI loaded on this terminal!")

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -90,12 +90,15 @@ var/const/HOLOPAD_MODE = 0
 		user.eyeobj.setLoc(get_turf(src))
 	else if(!hologram)//If there is no hologram, possibly make one.
 		activate_holo(user)
-	else if(master==user)//If there is a hologram, remove it. But only if the user is the master. Otherwise do nothing.
+	else if(master == user)//If there is a hologram, remove it. But only if the user is the master. Otherwise do nothing.
 		clear_holo()
 	return
 
 /obj/machinery/hologram/holopad/proc/activate_holo(mob/living/silicon/ai/user)
 	if(!(stat & NOPOWER) && user.eyeobj.loc == src.loc)//If the projector has power and client eye is on it.
+		if(user.holo)
+			var/obj/machinery/hologram/holopad/current = user.holo
+			current.clear_holo()
 		if(!hologram)//If there is not already a hologram.
 			create_holo(user)//Create one.
 			src.visible_message("A holographic image of [user] flicks to life right before your eyes!")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1427,7 +1427,8 @@
 
 		message_admins("\red Admin [key_name_admin(usr)] AIized [key_name_admin(H)]!", 1)
 		log_admin("[key_name(usr)] AIized [key_name(H)]")
-		H.AIize()
+		var/mob/living/silicon/ai/ai_character = H.AIize()
+		ai_character.moveToAILandmark()
 
 
 	else if(href_list["makemask"])

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -416,6 +416,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 						call(/datum/game_mode/proc/add_law_zero)(new_character)
 				if("AI")
 					new_character = new_character.AIize()
+					var/mob/living/silicon/ai/ai_character = new_character
+					ai_character.moveToAILandmark()
 					if(new_character.mind.special_role=="traitor")
 						call(/datum/game_mode/proc/add_law_zero)(new_character)
 				//Add aliens.

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -875,12 +875,7 @@
 										modified = 1
 
 										spawn()
-											if(istype(usr,/mob/living/carbon/human))
-												//var/mob/living/carbon/human/U = usr
-												sec_hud_set_security_status()
-											if(istype(usr,/mob/living/silicon/robot))
-												//var/mob/living/silicon/robot/U = usr
-												sec_hud_set_security_status()
+											sec_hud_set_security_status()
 
 			if(!modified)
 				to_chat(usr, "\red Unable to locate a data core entry for this person.")
@@ -1005,12 +1000,7 @@
 										PDA_Manifest.Cut()
 
 									spawn()
-										if(istype(usr,/mob/living/carbon/human))
-											//var/mob/living/carbon/human/U = usr
-											sec_hud_set_security_status()
-										if(istype(usr,/mob/living/silicon/robot))
-											//var/mob/living/silicon/robot/U = usr
-											sec_hud_set_security_status()
+										sec_hud_set_security_status()
 
 			if(!modified)
 				to_chat(usr, "\red Unable to locate a data core entry for this person.")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1062,3 +1062,25 @@ var/list/ai_verbs_default = list(
 	eyeobj.setLoc(get_turf(C))
 	client.eye = eyeobj
 	return 1
+
+/mob/living/silicon/ai/proc/malfhacked(obj/machinery/power/apc/apc)
+	malfhack = null
+	malfhacking = 0
+	clear_alert("hackingapc")
+
+	if(!istype(apc) || qdeleted(apc) || apc.stat & BROKEN)
+		to_chat(src, "<span class='danger'>Hack aborted. The designated APC no longer exists on the power network.</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, 1)
+	else if(apc.aidisabled)
+		to_chat(src, "<span class='danger'>Hack aborted. [apc] is no longer responding to our systems.</span>")
+		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, 1)
+	else
+		malf_picker.processing_time += 10
+
+		apc.malfai = parent || src
+		apc.malfhack = TRUE
+		apc.locked = TRUE
+
+		playsound(get_turf(src), 'sound/machines/ding.ogg', 50, 1)
+		to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
+		apc.update_icon()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -95,12 +95,7 @@ var/list/ai_verbs_default = list(
 
 	var/obj/machinery/camera/portable/builtInCamera
 
-	//var/obj/item/borg/sight/hud/sec/sechud = null
-	//var/obj/item/borg/sight/hud/med/healthhud = null
-
 	var/arrivalmsg = "$name, $rank, has arrived on the station."
-	med_hud = DATA_HUD_MEDICAL_BASIC
-	sec_hud = DATA_HUD_SECURITY_BASIC
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	src.verbs |= ai_verbs_default

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -65,6 +65,7 @@ var/global/list/empty_playable_ai_cores = list()
 				loc_landmark = sloc
 
 	forceMove(loc_landmark.loc)
+	view_core()
 
 // Before calling this, make sure an empty core exists, or this will no-op
 /mob/living/silicon/ai/proc/moveToEmptyCore()
@@ -77,6 +78,6 @@ var/global/list/empty_playable_ai_cores = list()
 	empty_playable_ai_cores -= C
 
 	forceMove(C.loc)
-
+	view_core()
 
 	qdel(C)

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -42,3 +42,41 @@ var/global/list/empty_playable_ai_cores = list()
 			current_mode.possible_traitors.Remove(src)
 
 	qdel(src)
+
+
+/mob/living/silicon/ai/proc/moveToAILandmark()
+	var/obj/loc_landmark
+	for(var/obj/effect/landmark/start/sloc in landmarks_list)
+		if(sloc.name != "AI")
+			continue
+		if(locate(/mob/living) in sloc.loc)
+			continue
+		loc_landmark = sloc
+	if(!loc_landmark)
+		for(var/obj/effect/landmark/tripai in landmarks_list)
+			if(tripai.name == "tripai")
+				if(locate(/mob/living) in tripai.loc)
+					continue
+				loc_landmark = tripai
+	if(!loc_landmark)
+		to_chat(src, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
+		for(var/obj/effect/landmark/start/sloc in landmarks_list)
+			if(sloc.name == "AI")
+				loc_landmark = sloc
+
+	forceMove(loc_landmark.loc)
+
+// Before calling this, make sure an empty core exists, or this will no-op
+/mob/living/silicon/ai/proc/moveToEmptyCore()
+	if(!empty_playable_ai_cores.len)
+		log_debug("moveToEmptyCore called without any available cores")
+		return
+
+	// IsJobAvailable for AI checks that there is an empty core available in this list
+	var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
+	empty_playable_ai_cores -= C
+
+	forceMove(C.loc)
+
+
+	qdel(C)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -78,15 +78,12 @@ var/list/robot_verbs_default = list(
 
 	var/updating = 0 //portable camera camerachunk update
 
-	hud_possible = list(SPECIALROLE_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_BATT_HUD,NATIONS_HUD)
+	hud_possible = list(SPECIALROLE_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_BATT_HUD, NATIONS_HUD)
 
 	var/magpulse = 0
 	var/ionpulse = 0 // Jetpack-like effect.
 	var/ionpulse_on = 0 // Jetpack-like effect.
 	var/datum/effect/system/ion_trail_follow/ion_trail // Ionpulse effect.
-
-	var/obj/item/borg/sight/hud/sec/sechud = null
-	var/obj/item/borg/sight/hud/med/healthhud = null
 
 	var/datum/action/item_action/toggle_research_scanner/scanner = null
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -296,18 +296,13 @@
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
 
-		character = character.AIize(move=0) // AIize the character, but don't move them yet
+		var/mob/living/silicon/ai/ai_character = character.AIize() // AIize the character, but don't move them yet
 
 		// IsJobAvailable for AI checks that there is an empty core available in this list
-		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
-		empty_playable_ai_cores -= C
+		ai_character.moveToEmptyCore()
+		AnnounceCyborg(ai_character, rank, "has been downloaded to the empty core in \the [get_area(ai_character)]")
 
-		character.loc = C.loc
-
-		AnnounceCyborg(character, rank, "has been downloaded to the empty core in \the [get_area(character)]")
-		ticker.mode.latespawn(character)
-
-		qdel(C)
+		ticker.mode.latespawn(ai_character)
 		qdel(src)
 		return
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -37,7 +37,9 @@
 	O.add_ai_verbs()
 
 	O.rename_self("AI",1)
-	qdel(src)
+
+	spawn()
+		qdel(src)
 	return O
 
 /mob/living/carbon/human/make_into_mask(var/should_gib = 0)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -7,14 +7,6 @@
 	spawning = 1
 	return ..()
 
-/mob/living/carbon/human/AIize(move=1) // 'move' argument needs defining here too because BYOND is dumb
-	if (notransform)
-		return
-	for(var/t in organs)
-		qdel(t)
-
-	return ..(move)
-
 /mob/living/carbon/AIize()
 	if (notransform)
 		return
@@ -40,34 +32,12 @@
 	else
 		O.key = key
 
-	var/obj/loc_landmark
-	for(var/obj/effect/landmark/start/sloc in landmarks_list)
-		if (sloc.name != "AI")
-			continue
-		if (locate(/mob/living) in sloc.loc)
-			continue
-		loc_landmark = sloc
-	if (!loc_landmark)
-		for(var/obj/effect/landmark/tripai in landmarks_list)
-			if (tripai.name == "tripai")
-				if(locate(/mob/living) in tripai.loc)
-					continue
-				loc_landmark = tripai
-	if (!loc_landmark)
-		to_chat(O, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
-		for(var/obj/effect/landmark/start/sloc in landmarks_list)
-			if (sloc.name == "AI")
-				loc_landmark = sloc
-
-	O.loc = loc_landmark.loc
-
 	O.on_mob_init()
 
 	O.add_ai_verbs()
 
 	O.rename_self("AI",1)
-	spawn
-		qdel(src)
+	qdel(src)
 	return O
 
 /mob/living/carbon/human/make_into_mask(var/should_gib = 0)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -851,7 +851,7 @@
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots)))                                                           \)
+		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots)))
 			if(!loud)
 				to_chat(user, "<span class='danger'>\The [src] has AI control disabled!</span>")
 				user << browse(null, "window=apc")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -748,11 +748,12 @@
 
 
 /obj/machinery/power/apc/proc/get_malf_status(mob/user)
-	if (ticker && ticker.mode && (user.mind in ticker.mode.malf_ai) && istype(user, /mob/living/silicon/ai))
-		if (src.malfai == (user:parent ? user:parent : user))
-			if (src.occupier == user)
+	if(ticker && ticker.mode && (user.mind in ticker.mode.malf_ai) && isAI(user))
+		var/mob/living/silicon/ai/AI = user
+		if((malfai == AI || malfai == AI.parent))
+			if(occupier == user)
 				return 3 // 3 = User is shunted in this APC
-			else if (istype(user.loc, /obj/machinery/power/apc))
+			else if(istype(user.loc, /obj/machinery/power/apc))
 				return 4 // 4 = User is shunted in another APC
 			else
 				return 2 // 2 = APC hacked by user, and user is in its core.
@@ -965,28 +966,28 @@
 			src.overload_lighting()
 
 	else if (href_list["malfhack"])
-		var/mob/living/silicon/ai/malfai = usr
-		if(get_malf_status(malfai)==1)
-			if (malfai.malfhacking)
-				to_chat(malfai, "You are already hacking an APC.")
+		var/mob/living/silicon/ai/AI = usr
+		if(get_malf_status(AI) == 1)
+			if(AI.malfhacking)
+				to_chat(AI, "<span class='warning'>You are already hacking an APC.</span>")
 				return 0
-			to_chat(malfai, "Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.")
-			malfai.malfhack = src
-			malfai.malfhacking = 1
+			to_chat(AI, "<span class='notice'>Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.</span>")
+			AI.malfhack = src
+			AI.malfhacking = 1
 			sleep(600)
 			if(src)
 				if (!aidisabled)
-					malfai.malfhack = null
-					malfai.malfhacking = 0
+					AI.malfhack = null
+					AI.malfhacking = 0
 					locked = 1
-					if (ticker.mode.config_tag == "malfunction")
-						if ((src.z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
+					if(ticker.mode.config_tag == "malfunction")
+						if((z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
 							ticker.mode:apcs++
-					if(usr:parent)
-						malfai = usr:parent
+					if(usr.parent)
+						malfai = AI.parent
 					else
-						malfai = usr
-					to_chat(malfai, "Hack complete. The APC is now under your exclusive control.")
+						malfai = AI
+					to_chat(AI, "<span class='notice'>Hack complete. The APC is now under your exclusive control.</span>")
 					update_icon()
 
 	else if (href_list["occupyapc"])
@@ -1000,7 +1001,7 @@
 	else if (href_list["toggleaccess"])
 		if(istype(usr, /mob/living/silicon))
 			if(emagged || aidisabled || (stat & (BROKEN|MAINT)))
-				to_chat(usr, "The APC does not respond to the command.")
+				to_chat(usr, "<span class='warning'>he APC does not respond to the command.</span>")
 			else
 				locked = !locked
 				update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -158,9 +158,7 @@
 /obj/machinery/power/apc/Destroy()
 	apcs -= src
 	if(malfai && operating)
-		if (ticker.mode.config_tag == "malfunction")
-			if (src.z == ZLEVEL_STATION)
-				ticker.mode:apcs--
+		malfai.malf_picker.processing_time = Clamp(malfai.malf_picker.processing_time - 10,0,1000)
 	area.power_light = 0
 	area.power_equip = 0
 	area.power_environ = 0
@@ -747,13 +745,12 @@
 	return ui_interact(user)
 
 
-/obj/machinery/power/apc/proc/get_malf_status(mob/user)
-	if(ticker && ticker.mode && (user.mind in ticker.mode.malf_ai) && isAI(user))
-		var/mob/living/silicon/ai/AI = user
-		if((malfai == AI || malfai == AI.parent))
-			if(occupier == user)
+/obj/machinery/power/apc/proc/get_malf_status(mob/living/silicon/ai/malf)
+	if(istype(malf) && malf.malf_picker)
+		if(malfai == (malf.parent || malf))
+			if(occupier == malf)
 				return 3 // 3 = User is shunted in this APC
-			else if(istype(user.loc, /obj/machinery/power/apc))
+			else if(istype(malf.loc, /obj/machinery/power/apc))
 				return 4 // 4 = User is shunted in another APC
 			else
 				return 2 // 2 = APC hacked by user, and user is in its core.
@@ -854,14 +851,7 @@
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if (                                                             \
-			src.aidisabled ||                                            \
-			malfhack && istype(malfai) &&                                \
-			(                                                            \
-				(istype(AI) && (malfai!=AI && malfai != AI.parent)) ||   \
-				(istype(robot) && (robot in malfai.connected_robots))    \
-			)                                                            \
-		)
+		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots)))                                                            \)
 			if(!loud)
 				to_chat(user, "<span class='danger'>\The [src] has AI control disabled!</span>")
 				user << browse(null, "window=apc")
@@ -966,29 +956,8 @@
 			src.overload_lighting()
 
 	else if (href_list["malfhack"])
-		var/mob/living/silicon/ai/AI = usr
-		if(get_malf_status(AI) == 1)
-			if(AI.malfhacking)
-				to_chat(AI, "<span class='warning'>You are already hacking an APC.</span>")
-				return 0
-			to_chat(AI, "<span class='notice'>Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.</span>")
-			AI.malfhack = src
-			AI.malfhacking = 1
-			sleep(600)
-			if(src)
-				if (!aidisabled)
-					AI.malfhack = null
-					AI.malfhacking = 0
-					locked = 1
-					if(ticker.mode.config_tag == "malfunction")
-						if((z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
-							ticker.mode:apcs++
-					if(AI.parent)
-						malfai = AI.parent
-					else
-						malfai = AI
-					to_chat(AI, "<span class='notice'>Hack complete. The APC is now under your exclusive control.</span>")
-					update_icon()
+		if(get_malf_status(usr))
+			malfhack(usr)
 
 	else if (href_list["occupyapc"])
 		if(get_malf_status(usr))
@@ -1010,36 +979,47 @@
 
 /obj/machinery/power/apc/proc/toggle_breaker()
 	operating = !operating
-
-	if(malfai)
-		if (ticker.mode.config_tag == "malfunction")
-			if ((src.z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
-				operating ? ticker.mode:apcs++ : ticker.mode:apcs--
-
-	src.update()
+	update()
 	update_icon()
 
-/obj/machinery/power/apc/proc/malfoccupy(var/mob/living/silicon/ai/malf)
+/obj/machinery/power/apc/proc/malfhack(mob/living/silicon/ai/malf)
+	if(!istype(malf))
+		return
+	if(get_malf_status(malf) != 1)
+		return
+	if(malf.malfhacking)
+		to_chat(malf, "<span class='warning'>You are already hacking an APC.</span>")
+		return
+	to_chat(malf, "<span class='notice'>Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process.</span>")
+	malf.malfhack = src
+	malf.malfhacking = addtimer(malf, "malfhacked", 600, FALSE, src)
+
+	var/obj/screen/alert/hackingapc/A
+	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)
+	A.target = src
+
+/obj/machinery/power/apc/proc/malfoccupy(mob/living/silicon/ai/malf)
 	if(!istype(malf))
 		return
 	if(istype(malf.loc, /obj/machinery/power/apc)) // Already in an APC
-		to_chat(malf, "<span class='warning'>You must evacuate your current apc first.</span>")
+		to_chat(malf, "<span class='warning'>You must evacuate your current apc first!</span>")
 		return
 	if(!malf.can_shunt)
-		to_chat(malf, "<span class='warning'>You cannot shunt.</span>")
+		to_chat(malf, "<span class='warning'>You cannot shunt!</span>")
 		return
 	if(!(src.z in config.station_levels))
 		return
-	src.occupier = new /mob/living/silicon/ai(src,malf.laws,null,1)
-	src.occupier.adjustOxyLoss(malf.getOxyLoss())
-	if(!findtext(src.occupier.name,"APC Copy"))
-		src.occupier.name = "[malf.name] APC Copy"
+	occupier = new /mob/living/silicon/ai(src,malf.laws,null,1)
+	occupier.adjustOxyLoss(malf.getOxyLoss())
+	if(!findtext(occupier.name, "APC Copy"))
+		occupier.name = "[malf.name] APC Copy"
 	if(malf.parent)
-		src.occupier.parent = malf.parent
+		occupier.parent = malf.parent
 	else
-		src.occupier.parent = malf
-	malf.mind.transfer_to(src.occupier)
-	src.occupier.eyeobj.name = "[src.occupier.name] (AI Eye)"
+		occupier.parent = malf
+	malf.shunted = 1
+	malf.mind.transfer_to(occupier)
+	occupier.eyeobj.name = "[occupier.name] (AI Eye)"
 	if(malf.parent)
 		qdel(malf)
 	src.occupier.verbs += /mob/living/silicon/ai/proc/corereturn
@@ -1351,9 +1331,9 @@
 
 /obj/machinery/power/apc/proc/set_broken()
 	if(malfai && operating)
-		if (ticker.mode.config_tag == "malfunction")
-			if ((src.z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
-				ticker.mode:apcs--
+		if(ticker.mode.config_tag == "malfunction")
+			if((src.z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
+				ticker.mode.apcs--
 	stat |= BROKEN
 	operating = 0
 	if(occupier)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -851,7 +851,7 @@
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots)))
+		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && ((malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
 			if(!loud)
 				to_chat(user, "<span class='danger'>\The [src] has AI control disabled!</span>")
 				user << browse(null, "window=apc")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -851,7 +851,7 @@
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && ((malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
+		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || ((istype(robot) && (robot in malfai.connected_robots)))))
 			if(!loud)
 				to_chat(user, "<span class='danger'>\The [src] has AI control disabled!</span>")
 				user << browse(null, "window=apc")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -994,10 +994,6 @@
 	malf.malfhack = src
 	malf.malfhacking = addtimer(malf, "malfhacked", 600, FALSE, src)
 
-	var/obj/screen/alert/hackingapc/A
-	A = malf.throw_alert("hackingapc", /obj/screen/alert/hackingapc)
-	A.target = src
-
 /obj/machinery/power/apc/proc/malfoccupy(mob/living/silicon/ai/malf)
 	if(!istype(malf))
 		return
@@ -1006,7 +1002,6 @@
 		return
 	if(!malf.can_shunt)
 		to_chat(malf, "<span class='warning'>You cannot shunt!</span>")
-		return
 	if(!(src.z in config.station_levels))
 		return
 	occupier = new /mob/living/silicon/ai(src,malf.laws,null,1)
@@ -1017,7 +1012,6 @@
 		occupier.parent = malf.parent
 	else
 		occupier.parent = malf
-	malf.shunted = 1
 	malf.mind.transfer_to(occupier)
 	occupier.eyeobj.name = "[occupier.name] (AI Eye)"
 	if(malf.parent)
@@ -1333,7 +1327,7 @@
 	if(malfai && operating)
 		if(ticker.mode.config_tag == "malfunction")
 			if((src.z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
-				ticker.mode.apcs--
+				ticker.mode:apcs--
 	stat |= BROKEN
 	operating = 0
 	if(occupier)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -983,7 +983,7 @@
 					if(ticker.mode.config_tag == "malfunction")
 						if((z in config.station_levels)) //if (is_type_in_list(get_area(src), the_station_areas))
 							ticker.mode:apcs++
-					if(usr.parent)
+					if(AI.parent)
 						malfai = AI.parent
 					else
 						malfai = AI

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -851,14 +851,14 @@
 	if (istype(user, /mob/living/silicon))
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
-		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots)))                                                            \)
+		if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai != AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots)))                                                           \)
 			if(!loud)
 				to_chat(user, "<span class='danger'>\The [src] has AI control disabled!</span>")
 				user << browse(null, "window=apc")
 				user.unset_machine()
 			return 0
 	else
-		if ((!in_range(src, user) || !istype(src.loc, /turf)))
+		if((!in_range(src, user) || !istype(src.loc, /turf)))
 			return 0
 
 	var/mob/living/carbon/human/H = user


### PR DESCRIPTION
 - Moves AI movement to their own procs, and cleans up their creation
 - The secHUD/medHUD will now update properly when the AI changes a setting.
 - It is no longer possible to have more than one hologram active per AI.
 - Late-joining AIs will no longer runtime before replacing the unused core they're meant to be in.
  - This was leaving the unused core, allowing further AIs to late-join... and moving none of them to the station. Whoops!
 - Both roundstart and late-join AIs will have their cameras properly centered on their core after spawning.
 - The new player panel will no longer attempt to be shown to the clientless new_player that exists after a round-start AI spawns.

Maybe fixes #174 and #175 