### PR TITLE
Remoção de assistentes

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -53,6 +53,7 @@
 	var/allow_ai = 1					// allow ai job
 	var/hostedby = null
 	var/respawn = 0
+	var/civilian_allowed = 0
 	var/guest_jobban = 1
 	var/usewhitelist = 0
 	var/mods_are_mentors = 0
@@ -64,7 +65,7 @@
 
 	var/reactionary_explosions = 0 //If we use reactionary explosions, explosions that react to walls and doors
 
-	var/assistantlimit = 0 //enables assistant limiting
+	var/assistantlimit = 1 //enables assistant limiting
 	var/assistantratio = 2 //how many assistants to security members
 
 	var/traitor_objectives_amount = 2

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -265,15 +265,16 @@ var/global/datum/controller/occupations/job_master
 		HandleFeedbackGathering()
 
 		//People who wants to be assistants, sure, go on.
-		Debug("DO, Running Civilian Check 1")
-		var/datum/job/civ = new /datum/job/civilian()
-		var/list/civilian_candidates = FindOccupationCandidates(civ, 3)
-		Debug("AC1, Candidates: [civilian_candidates.len]")
-		for(var/mob/new_player/player in civilian_candidates)
-			Debug("AC1 pass, Player: [player]")
-			AssignRole(player, "Civilian")
-			civilian_candidates -= player
-		Debug("DO, AC1 end")
+		if(civilian_allowed)
+			Debug("DO, Running Civilian Check 1")
+			var/datum/job/civ = new /datum/job/civilian()
+			var/list/civilian_candidates = FindOccupationCandidates(civ, 3)
+			Debug("AC1, Candidates: [civilian_candidates.len]")
+			for(var/mob/new_player/player in civilian_candidates)
+				Debug("AC1 pass, Player: [player]")
+				AssignRole(player, "Civilian")
+				civilian_candidates -= player
+			Debug("DO, AC1 end")
 
 		//Select one head
 		Debug("DO, Running Head Check")

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -52,7 +52,7 @@ var/global/datum/controller/occupations/job_master
 			if(jobban_isbanned(player, rank))	return 0
 			if(!job.player_old_enough(player.client)) return 0
 			if(!is_job_whitelisted(player, rank)) return 0
-			if(istype(job, GetJob("Civilian")) && !civilian_allowed) return 0
+			if(istype(job, GetJob("Civilian")) && !config.civilian_allowed) return 0
 			var/position_limit = job.total_positions
 			if(!latejoin)
 				position_limit = job.spawn_positions
@@ -266,7 +266,7 @@ var/global/datum/controller/occupations/job_master
 		HandleFeedbackGathering()
 
 		//People who wants to be assistants, sure, go on.
-		if(civilian_allowed)
+		if(config.civilian_allowed)
 			Debug("DO, Running Civilian Check 1")
 			var/datum/job/civ = new /datum/job/civilian()
 			var/list/civilian_candidates = FindOccupationCandidates(civ, 3)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -52,7 +52,7 @@ var/global/datum/controller/occupations/job_master
 			if(jobban_isbanned(player, rank))	return 0
 			if(!job.player_old_enough(player.client)) return 0
 			if(!is_job_whitelisted(player, rank)) return 0
-			if(istype(job, GetJob("Civilian")&& !civilian_allowed) return 0
+			if(istype(job, GetJob("Civilian")) && !civilian_allowed) return 0
 			var/position_limit = job.total_positions
 			if(!latejoin)
 				position_limit = job.spawn_positions

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -52,6 +52,7 @@ var/global/datum/controller/occupations/job_master
 			if(jobban_isbanned(player, rank))	return 0
 			if(!job.player_old_enough(player.client)) return 0
 			if(!is_job_whitelisted(player, rank)) return 0
+			if(istype(job, GetJob("Civilian")&& !civilian_allowed) return 0
 			var/position_limit = job.total_positions
 			if(!latejoin)
 				position_limit = job.spawn_positions

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -73,8 +73,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/change_human_appearance_self,	/* Allows the human-based mob itself change its basic appearance */
 	/client/proc/debug_variables,
 	/client/proc/show_snpc_verbs,
-	/client/proc/reset_all_tcs			/*resets all telecomms scripts*/
-	/client/proc/DebugGameMode
+	/client/proc/reset_all_tcs,			/*resets all telecomms scripts*/
+	/client/proc/DebugGameMode,
 	/client/proc/toggle_civilians
 )
 var/list/admin_verbs_ban = list(
@@ -135,7 +135,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/set_ooc,
-	/client/proc/reset_ooc
+	/client/proc/reset_ooc,
 	/client/proc/toggle_civilians
 	)
 var/list/admin_verbs_debug = list(
@@ -163,7 +163,7 @@ var/list/admin_verbs_debug = list(
 	/proc/machine_upgrade,
 	/client/proc/map_template_load,
 	/client/proc/map_template_upload,
-	/client/proc/view_runtimes
+	/client/proc/view_runtimes,
 	/client/proc/DebugGameMode
 	)
 var/list/admin_verbs_possess = list(

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -74,6 +74,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/debug_variables,
 	/client/proc/show_snpc_verbs,
 	/client/proc/reset_all_tcs			/*resets all telecomms scripts*/
+	/client/proc/DebugGameMode
+	/client/proc/toggle_civilians
 )
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -134,6 +136,7 @@ var/list/admin_verbs_server = list(
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/set_ooc,
 	/client/proc/reset_ooc
+	/client/proc/toggle_civilians
 	)
 var/list/admin_verbs_debug = list(
 	/client/proc/cmd_admin_list_open_jobs,
@@ -161,6 +164,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/map_template_load,
 	/client/proc/map_template_upload,
 	/client/proc/view_runtimes
+	/client/proc/DebugGameMode
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,
@@ -868,6 +872,17 @@ var/list/admin_verbs_snpc = list(
 		job_master.FreeRole(job)
 		log_admin("[key_name(usr)] has freed a job slot for [job].")
 		message_admins("[key_name_admin(usr)] has freed a job slot for [job].")
+
+/client/proc/toggle_civilians()
+	set name = "Toggle Civilians entry"
+	set category = "Server"
+
+	if(!check_rights(R_SERVER))
+		return
+
+	config.civilian_allowed = !(config.civilian_allowed )
+	log_admin("[key_name(usr)] has [config.civilian_allowed  ? "enabled" : "disabled"] civilians.")
+	message_admins("[key_name_admin(usr)] has [config.civilian_allowed  ? "enabled" : "disabled"] civilians.")
 
 /client/proc/toggleattacklogs()
 	set name = "Toggle Attack Log Messages"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -246,7 +246,7 @@
 	if(!is_job_whitelisted(src, rank))	 return 0
 	if(!job.player_old_enough(src.client))	return 0
 	if(job.admin_only && !(check_rights(R_ADMIN, 0))) return 0
-
+	if(job.title == "Civilian"&& !config.civilian_allowed) return 0
 	if(config.assistantlimit)
 		if(job.title == "Civilian")
 			var/count = 0


### PR DESCRIPTION
A feature mais pedida pelo nopm.
Um verbo que decide se os assistentes podem entrar ou não.
Correcção mínima no verbo de debug game mode para funcionar com o hide e show verbs que passou ao lado.