### PR TITLE
Changeling related fixes

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -76,17 +76,17 @@
 	var/datum/money_account/initial_account
 
 /datum/mind/proc/transfer_to(mob/living/new_character)
+	var/datum/atom_hud/antag/hud_to_transfer = antag_hud //we need this because leave_hud() will clear this list
 	if(!istype(new_character))
 		log_to_dd("## DEBUG: transfer_to(): Some idiot has tried to transfer_to() a non mob/living mob. Please inform Carn")
 	if(current)					//remove ourself from our old body's mind variable
 		current.mind = null
+		leave_all_huds() //leave all the huds in the old body, so it won't get huds if somebody else enters it
 
 		nanomanager.user_transferred(current, new_character)
 
 	if(new_character.mind)		//remove any mind currently in our new body's mind variable
 		new_character.mind.current = null
-	var/datum/atom_hud/antag/hud_to_transfer = antag_hud//we need this because leave_hud() will clear this list
-	leave_all_huds()									//leave all the huds in the old body, so it won't get huds if somebody else enters it
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -249,7 +249,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	var/list/absorbed_dna = list()
 	var/list/absorbed_languages = list()
 	var/list/protected_dna = list() //DNA that is not lost when capacity is otherwise full.
-	var/dna_max = 4 //How many extra DNA strands the changeling can store for transformation.
+	var/dna_max = 5 //How many total DNA strands the changeling can store for transformation.
 	var/absorbedcount = 1 //Would require at least 1 sample to take on the form of a human
 	var/chem_charges = 20
 	var/chem_recharge_rate = 0.5
@@ -281,7 +281,6 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		changelingID = "[honorific] [changelingID]"
 	else
 		changelingID = "[honorific] [rand(1,999)]"
-	absorbed_dna.len = dna_max
 
 /datum/changeling/proc/regenerate()
 	chem_charges = min(max(0, chem_charges + chem_recharge_rate - chem_recharge_slowdown), chem_storage)
@@ -293,14 +292,35 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		if(dna_owner == DNA.real_name)
 			return DNA
 
-/datum/changeling/proc/has_dna(var/datum/dna/tDNA)
+/datum/changeling/proc/find_dna(var/datum/dna/tDNA)
 	for(var/datum/dna/D in (absorbed_dna + protected_dna))
 		if(tDNA.unique_enzymes == D.unique_enzymes && tDNA.uni_identity == D.uni_identity && tDNA.species == D.species)
-			return 1
+			return D
+	return null
+
+/datum/changeling/proc/has_dna(var/datum/dna/tDNA)
+	if(find_dna(tDNA))
+		return 1
 	return 0
 
+// A changeling's DNA is "stale" if their current form's DNA is the oldest DNA in a full list
+/datum/changeling/proc/using_stale_dna(var/mob/living/carbon/user)
+	var/current_dna = find_dna(user.dna)
+	if(absorbed_dna.len < dna_max)
+		return 0 // Still more room for DNA
+	if(!current_dna || !(current_dna in absorbed_dna))
+		return 1 // Oops, our current DNA was somehow not absorbed; force a transformation
+	if(absorbed_dna[1] == current_dna)
+		return 1 // Oldest DNA is the current DNA
+	return 0
+
+/datum/changeling/proc/trim_dna()
+	absorbed_dna -= null
+	if(absorbed_dna.len > dna_max)
+		absorbed_dna.Cut(1, (absorbed_dna.len - dna_max) + 1)
+
 /datum/changeling/proc/can_absorb_dna(var/mob/living/carbon/user, var/mob/living/carbon/target)
-	if(absorbed_dna[1] == user.dna)//If our current DNA is the stalest, we gotta ditch it.
+	if(using_stale_dna(user))//If our current DNA is the stalest, we gotta ditch it.
 		to_chat(user, "<span class='warning'>We have reached our capacity to store genetic information! We must transform before absorbing more.</span>")
 		return
 

--- a/code/game/gamemodes/changeling/changeling_power.dm
+++ b/code/game/gamemodes/changeling/changeling_power.dm
@@ -73,12 +73,6 @@
 		return 0
 	return 1
 
-/obj/effect/proc_holder/changeling/proc/transfer_changeling_powers(var/mob/living/carbon/user, var/mob/living/carbon/target)
-	if(istype(target, /mob/living/carbon)) // so we don't runtime, I don't even know why it's necessary as it needs a grab
-		var/datum/changeling/c = user.mind.changeling
-		var/datum/changeling/t = target.mind.changeling
-		c.purchasedpowers = t.purchasedpowers
-
 //used in /mob/Stat()
 /obj/effect/proc_holder/changeling/proc/can_be_used_by(var/mob/user)
 	if(!ishuman(user))

--- a/code/game/gamemodes/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/changeling/evolution_menu.dm
@@ -376,6 +376,7 @@ var/list/sting_paths
 
 	var/mob/living/carbon/C = src		//only carbons have dna now, so we have to typecaste
 	mind.changeling.absorbed_dna |= C.dna
+	mind.changeling.trim_dna()
 	return 1
 
 //Used to dump the languages from the changeling datum into the actual mob.

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -85,8 +85,6 @@
 
 //Absorbs the target DNA.
 /datum/changeling/proc/absorb_dna(mob/living/carbon/T, var/mob/user)
-	if(absorbed_dna.len)
-		absorbed_dna.Cut(1,2)
 	T.dna.real_name = T.real_name //Set this again, just to be sure that it's properly set.
 	var/datum/dna/new_dna = T.dna.Clone()
 	//Steal all of their languages!
@@ -108,3 +106,4 @@
 			protected_dna |= new_dna
 			return
 	absorbed_dna |= new_dna
+	trim_dna()

--- a/code/game/gamemodes/changeling/powers/hivemind.dm
+++ b/code/game/gamemodes/changeling/powers/hivemind.dm
@@ -62,7 +62,7 @@ var/list/datum/dna/hivemind_bank = list()
 	if(!..())
 		return
 	var/datum/changeling/changeling = user.mind.changeling
-	if(changeling.absorbed_dna[1] == user.dna)//If our current DNA is the stalest, we gotta ditch it.
+	if(changeling.using_stale_dna(user))//If our current DNA is the stalest, we gotta ditch it.
 		to_chat(user, "<span class='warning'>We have reached our capacity to store genetic information! We must transform before absorbing more.</span>")
 		return
 	return 1
@@ -84,8 +84,6 @@ var/list/datum/dna/hivemind_bank = list()
 	if(!chosen_dna)
 		return
 
-	if(changeling.absorbed_dna.len)
-		changeling.absorbed_dna.Cut(1,2)
 	changeling.store_dna(chosen_dna, user)
 	to_chat(user, "<span class='notice'>We absorb the DNA of [S] from the air.</span>")
 	feedback_add_details("changeling_powers","HD")

--- a/code/game/gamemodes/changeling/powers/swap_form.dm
+++ b/code/game/gamemodes/changeling/powers/swap_form.dm
@@ -38,10 +38,12 @@
 
 	to_chat(target, "<span class='userdanger'>[user] tightens their grip as a painful sensation invades your body.</span>")
 
+	changeling.absorbed_dna -= changeling.find_dna(user.dna)
+	changeling.protected_dna -= changeling.find_dna(user.dna)
+	changeling.absorbedcount -= 1
 	if(!changeling.has_dna(target.dna))
 		changeling.absorb_dna(target, user)
-	changeling.protected_dna -= user.dna
-	changeling.absorbed_dna -= user.dna
+	changeling.trim_dna()
 
 	var/mob/dead/observer/ghost = target.ghostize(0)
 	user.mind.transfer_to(target)
@@ -52,6 +54,6 @@
 	user.Paralyse(2)
 	target.add_language("Changeling")
 	user.remove_language("Changeling")
-	transfer_changeling_powers(user, target)
 
 	to_chat(target, "<span class='warning'>Our genes cry out as we swap our [user] form for [target].</span>")
+	return 1

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -82,11 +82,12 @@
 // Calling update_interface() in /mob/Login() causes the Cyborg to immediately be ghosted; because of winget().
 // Calling it in the overriden Login, such as /mob/living/Login() doesn't cause this.
 /mob/proc/update_interface()
-	if(client)
-		if(winget(src, "mainwindow.hotkey_toggle", "is-checked") == "true")
-			update_hotkey_mode()
-		else
-			update_normal_mode()
+	spawn() // Spawn off so winget/winset don't delay callers.
+		if(client)
+			if(winget(src, "mainwindow.hotkey_toggle", "is-checked") == "true")
+				update_hotkey_mode()
+			else
+				update_normal_mode()
 
 /mob/proc/update_hotkey_mode()
 	var/hotkeyname = "hotkeymode"
@@ -94,7 +95,7 @@
 		var/hotkeys = client.hotkeylist[client.hotkeytype]
 		hotkeyname = hotkeys[client.hotkeyon ? "on" : "off"]
 		client.hotkeyon = 1
-	winset(src, null, "mainwindow.macro=[hotkeyname] hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
+		winset(src, null, "mainwindow.macro=[hotkeyname] hotkey_toggle.is-checked=true mapwindow.map.focus=true input.background-color=#F0F0F0")
 
 /mob/proc/update_normal_mode()
 	var/hotkeyname = "macro"
@@ -102,4 +103,4 @@
 		var/hotkeys = client.hotkeylist[client.hotkeytype]//get the list containing the hotkey names
 		hotkeyname = hotkeys[client.hotkeyon ? "on" : "off"]//get the name of the hotkey, to not clutter winset() to much
 		client.hotkeyon = 0
-	winset(src, null, "mainwindow.macro=[hotkeyname] hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")
+		winset(src, null, "mainwindow.macro=[hotkeyname] hotkey_toggle.is-checked=false input.focus=true input.background-color=#D3B5B5")


### PR DESCRIPTION
 - Fixes Swap Form runtiming when trying to transfer changeling powers.
  - These are now transferred with the mind, so this wasn't even necessary.
 - Fixes Swap Form not deducting its cost.
  - It was missing a return 1.
 - Fixes Swap Form not consistently removing the DNA of the form being swapped out.
  - A new proc, find_dna, has been added to help locate cloned DNA.
 - Fixes Swap Form permanently reducing a changeling's maximum DNA slots when it does remove DNA.
  - A new proc, trim_dna, has been added to simplify trimming the DNA list without screwing it up.
 - Fixes Swap Form removing DNA, but not reducing the absorbed DNA count.
  - This allowed a changeling to swap between two bodies while racking up their DNA count.
    - Or rather, it would have, if Swap Form wasn't so utterly broken.
 - Fixes minds' transfer_to trying to remove huds from a null current mob.
  - This was causing another runtime when using Swap Form, since it leaves the victim's mind temporarily mobless.
 - Fixes runtimes in update_interface caused by clients vanishing between winget and winset.
  - Swap Form would hit this (if it didn't runtime earlier) when it ghosted the victim, then immediately transferred them to a new mob.
 - Changelings no longer keep null entries in their DNA list.
  - This made removing specific DNA problematic, as it would throw off how much DNA you could absorb before having to transform.
  - A new proc, using_stale_dna, has been added to replace checks that relied on null entries being shifted around.
    - In addition to checking whether the current form's DNA is the stalest, it also checks whether that DNA is even present, and treats a full list as stale if it's not.
    - It also uses find_dna to ensure it can find cloned DNA after using Swap Form.