### PR TITLE
Vore fixup

### DIFF
--- a/code/datums/vore/vore.dm
+++ b/code/datums/vore/vore.dm
@@ -14,7 +14,8 @@
 
 /datum/vore_controller/proc/digest(mob/living/carbon/human/prey)
 	var/bruteloss = 10
-	prey.adjustBruteLoss(bruteloss)
+	while(prey.health > -90)
+		prey.adjustBruteLoss(bruteloss)
 	if(prey.health <= -90) // 0 = critical, -90 = death
 		absorb(prey)
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -109,7 +109,9 @@
 			else
 				src.grabbedby(M)
 				return 1
-
+			if(M == src && M.swallow_controller.belly_contents.len > 0)
+				M.swallow_controller.regurgitate(M.swallow_controller.belly_contents[1])
+				return
 		if(I_HARM)
 			if(attacker_style && attacker_style.harm_act(H, src))
 				return 1

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -419,12 +419,6 @@
 						qdel(src)
 					else
 						attacker.visible_message("<span class='notice'>[affecting] escapes from [attacker]'s grip!</span>", "<span class='notice'>[affecting] escapes from your grip!</span>")
-				if(3)
-					attacker.visible_message("<span class='notice'>[attacker] is vomiting [affecting]!</span>", "<span class='notice'>You start vomiting [affecting] out!</span>")
-					if(do_after(attacker, checktime(user, affecting), target = affecting))
-						attacker.visible_message("<span class='notice'>[attacker] vomits [affecting] out!</span>", "<span class='notice'>You vomit [affecting] out!</span>")
-						attacker.swallow_controller.regurgitate(affecting)
-
 /obj/item/weapon/grab/proc/checkvalid(var/mob/attacker, var/mob/prey) //does all the checking for the attack proc to see if a mob can eat another with the grab
 	if(ishuman(attacker) && (/datum/dna/gene/basic/grant_spell/mattereater in attacker.active_genes)) // MATTER EATER CARES NOT OF YOUR FORM
 		return 2
@@ -434,9 +428,6 @@
 
 	if(ishuman(attacker))
 		return 2
-
-	if(attacker.swallow_controller.belly_contents.len > 0)
-		return 3
 
 	if(isalien(attacker) && iscarbon(prey)) //Xenomorphs eating carbon mobs
 		return 1


### PR DESCRIPTION
- Consertado o bug da presa não levar dano de digestão após ser engolida.
- Adicionada função de regurgitar a presa, grab e clica no seu personagem.