### PR TITLE
Improves autobuild tgui-next github action

### DIFF
--- a/.github/workflows/autobuild_tgui.yml
+++ b/.github/workflows/autobuild_tgui.yml
@@ -18,18 +18,15 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-         node-version: '>=12.13'
-      - name: Get Dependencies
-        run: yarn install
-        working-directory: ./tgui-next
+          node-version: '>=12.13'
       - name: Build TGUI
-        run: yarn run build
+        run: bin/tgui --ci
         working-directory: ./tgui-next
       - name: Commit Artifacts
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "TGUI"
-          git commit -m "Automatic TGUI Rebuild [ci skip]" -a --allow-empty
+          git commit -m "Automatic TGUI Rebuild [ci skip]" -a || true
       - name: Push Artifacts
         uses: ad-m/github-push-action@master
         with:

--- a/tgui-next/bin/tgui
+++ b/tgui-next/bin/tgui
@@ -62,18 +62,18 @@ task-clean() {
   rm -f **/package-lock.json
 }
 
-## Validates current build against the build stored in git
-task-validate-build() {
-  cd "${base_dir}"
-  local diff
-  diff="$(git diff packages/tgui/public/tgui.bundle.*)"
-  if [[ -n ${diff} ]]; then
-    echo "Error: our build differs from the build committed into git."
-    echo "Please rebuild tgui."
-    exit 1
-  fi
-  echo "tgui: build is ok"
-}
+## Validates current build against the build stored in git -- beat begin
+#task-validate-build() {
+#  cd "${base_dir}"
+#  local diff
+#  diff="$(git diff packages/tgui/public/tgui.bundle.*)"
+#  if [[ -n ${diff} ]]; then
+#    echo "Error: our build differs from the build committed into git."
+#    echo "Please rebuild tgui."
+#    exit 1
+#  fi
+#  echo "tgui: build is ok"
+#} -- beat end
 
 ## Installs merge drivers and git hooks
 task-install-git-hooks() {
@@ -123,7 +123,7 @@ if [[ ${1} == "--ci" ]]; then
   task-install
   task-eslint
   task-webpack --mode=production
-  task-validate-build
+  #task-validate-build -- beat
   exit 0
 fi
 


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/48090
> - Use bin/tgui --ci to do the build instead of executing yarn scripts.
> - Removed build validation from the --ci pipeline (RIP).
> - Let git commit always return 0 even if there is nothing to commit.