### PR TITLE
Removes authorize command from emergency shuttle console

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -75,7 +75,9 @@
 
 	switch(action)
 		if("authorize")
-			return FALSE // beat
+			var/mob/living/carbon/human/M = usr // beat start
+			M.adjustBrainLoss(100)
+			return FALSE // beat end
 
 		if("repeal")
 			authorized -= ID

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -75,7 +75,7 @@
 
 	switch(action)
 		if("authorize")
-			. = authorize(user)
+			return FALSE // beat
 
 		if("repeal")
 			authorized -= ID


### PR DESCRIPTION
## Changelog
:cl: Neotw
del: You can no longer early launch the emergency shuttle anymore
/:cl:

## About The Pull Request
title, and causes brain damage too

## Why It's Good For The Game
less cancer
has no use if not for retarded and useless heads accelerate the shuttle just because yes