### PR TITLE
Fixes ghost stone being able to revive thanos

### DIFF
--- a/hippiestation/code/modules/gauntlet/ghost.dm
+++ b/hippiestation/code/modules/gauntlet/ghost.dm
@@ -259,6 +259,10 @@
 			to_chat(caller, "<span class='danger'>They aren't dead enough yet.</span>")
 			revert_cast()
 			return
+		if(istype(H.dna.species, /datum/species/ganymede))
+			to_chat(caller, "<span class='danger'>You cannot revive Thanos!</span>")
+			revert_cast()
+			return FALSE
 		H.revive(TRUE, TRUE)
 		H.grab_ghost()
 		H.cluwneify()

--- a/hippiestation/code/modules/gauntlet/ghost.dm
+++ b/hippiestation/code/modules/gauntlet/ghost.dm
@@ -259,10 +259,10 @@
 			to_chat(caller, "<span class='danger'>They aren't dead enough yet.</span>")
 			revert_cast()
 			return
-		if(istype(H.dna.species, /datum/species/ganymede))
+		if(istype(H.dna.species, /datum/species/ganymede)) // beat start
 			to_chat(caller, "<span class='danger'>You cannot revive Thanos!</span>")
 			revert_cast()
-			return FALSE
+			return FALSE // beat end
 		H.revive(TRUE, TRUE)
 		H.grab_ghost()
 		H.cluwneify()


### PR DESCRIPTION

## Changelog
:cl: Neotw
fix: You cannot revive thanos with the ghost stone anymore
/:cl:

