### PR TITLE
Fixes vents and scrubbers icons

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -391,7 +391,7 @@
 	if (holding)
 		data["holdingTank"] = list()
 		data["holdingTank"]["name"] = holding.name
-		data["holdingTank"]["tankPressure"] = round(air_contents.return_pressure() ? air_contents.return_pressure() : 0)
+		data["holdingTank"]["tankPressure"] = round(holding.air_contents.return_pressure())
 	return data
 
 /obj/machinery/portable_atmospherics/canister/ui_act(action, params)

--- a/hippiestation.dme
+++ b/hippiestation.dme
@@ -3248,7 +3248,6 @@
 #include "hippiestation\code\modules\atmospherics\machinery\portable\canister.dm"
 #include "hippiestation\code\modules\atmospherics\machinery\portable\other\miner.dm"
 #include "hippiestation\code\modules\atmospherics\unary_devices\vent_pump.dm"
-#include "hippiestation\code\modules\atmospherics\unary_devices\vent_scrubber.dm"
 #include "hippiestation\code\modules\awaymissions\corpse.dm"
 #include "hippiestation\code\modules\cargo\packs.dm"
 #include "hippiestation\code\modules\client\asset_cache.dm"

--- a/hippiestation/code/modules/atmospherics/unary_devices/vent_pump.dm
+++ b/hippiestation/code/modules/atmospherics/unary_devices/vent_pump.dm
@@ -1,5 +1,4 @@
 /obj/machinery/atmospherics/components/unary/vent_pump
-	icon_hippie = 'hippiestation/icons/obj/atmospherics/components/unary_devices.dmi'
 	var/cover = 0 //For hiding tiny objects in, 1 means cover is up, can hide.
 	var/max_n_of_items = 5
 

--- a/hippiestation/code/modules/atmospherics/unary_devices/vent_scrubber.dm
+++ b/hippiestation/code/modules/atmospherics/unary_devices/vent_scrubber.dm
@@ -1,2 +1,0 @@
-/obj/machinery/atmospherics/components/unary/vent_scrubber
-	icon_hippie = 'hippiestation/icons/obj/atmospherics/components/unary_devices.dmi'


### PR DESCRIPTION
## About The Pull Request
they're showing the old icons in the random rooms
changes from hippie commits:
[`c65abe0`](https://github.com/HippieStation/HippieStation/commit/c65abe0e230b6ca4fca376546206eb528e20b503)
[`fb7f3dc`](https://github.com/HippieStation/HippieStation/commit/fb7f3dc093b8be923e5758b85301683feb246d4f)
[`dcbdb22`](https://github.com/HippieStation/HippieStation/commit/dcbdb220a16b07f1b1541636045f028f91bd9370)
also [`c329a91`](https://github.com/HippieStation/HippieStation/commit/c329a912399105477c6476685ed22d2f035c76db)