### PR TITLE
UI for the normal protolathe and the circuit imprinter

### DIFF
--- a/beatstation.dme
+++ b/beatstation.dme
@@ -63,6 +63,8 @@
 #include "beatstation\code\modules\research\designs\machine_designs.dm"
 #include "beatstation\code\modules\research\designs\nanite_designs.dm"
 #include "beatstation\code\modules\research\designs\weapon_designs.dm"
+#include "beatstation\code\modules\research\machinery\circuit_imprinter.dm"
+#include "beatstation\code\modules\research\machinery\protolathe.dm"
 #include "beatstation\code\modules\research\techweb\all_nodes.dm"
 #include "beatstation\code\modules\stock_market\articles.dm"
 #include "beatstation\code\modules\stock_market\computer.dm"

--- a/beatstation/code/modules/research/machinery/circuit_imprinter.dm
+++ b/beatstation/code/modules/research/machinery/circuit_imprinter.dm
@@ -1,0 +1,3 @@
+/obj/machinery/rnd/production/circuit_imprinter
+	requires_console = FALSE
+	consoleless_interface = TRUE

--- a/beatstation/code/modules/research/machinery/protolathe.dm
+++ b/beatstation/code/modules/research/machinery/protolathe.dm
@@ -1,0 +1,3 @@
+/obj/machinery/rnd/production/protolathe
+	requires_console = FALSE
+	consoleless_interface = TRUE

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -326,7 +326,7 @@ Class Procs:
 		user.changeNext_move(CLICK_CD_MELEE)
 		user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
 		user.visible_message("<span class='danger'>[user.name] smashes against \the [src.name] with its paws.</span>", null, null, COMBAT_MESSAGE_RANGE)
-		take_damage(4, BRUTE, "melee", FALSE)
+		take_damage(4, BRUTE, "melee", TRUE)
 
 /obj/machinery/attack_robot(mob/user)
 	if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON) && !IsAdminGhost(user))


### PR DESCRIPTION
## Changelog
:cl: Neotw
tweak: Normal protolathes and circuit imprinters now uses a UI
/:cl:

## About The Pull Request
Makes them to use a UI, so you dont need to use a console
also, a fix from hippie commit
[241322e](https://github.com/HippieStation/HippieStation/commit/241322e5d22422fca66413dd2beb845f3fd4f6d8)
