### PR TITLE
Increases the cost of the energy butterfly knife

### DIFF
--- a/beatstation/code/modules/uplink/uplink_items.dm
+++ b/beatstation/code/modules/uplink/uplink_items.dm
@@ -17,3 +17,6 @@
 	cost = 15
 	surplus = 20
 	exclude_modes = list(/datum/game_mode/infiltration)
+
+/datum/uplink_item/dangerous/butterfly
+	cost = 15


### PR DESCRIPTION

## Changelog
:cl: Neotw
balance: The energy butterfly knife now costs 15 TC
/:cl:

## About The Pull Request
Increases the cost of the energy butterfly knife to 15 TC

## Why It's Good For The Game
too op

