### PR TITLE
Revert "borers now spawns as a random event as it should be"

### DIFF
--- a/hippiestation/code/game/gamemodes/miniantags/borer/borer_events.dm
+++ b/hippiestation/code/game/gamemodes/miniantags/borer/borer_events.dm
@@ -2,7 +2,7 @@
 	name = "Borer"
 	typepath = /datum/round_event/borer
 	weight = 15
-	max_occurrences = 1 // beat -- let it be a random event
+	max_occurrences = 0
 	min_players = 15
 	earliest_start = 6000 // lower start time since borers arent too dangerous
 


### PR DESCRIPTION

## Changelog
:cl: Neotw
del: Borer is now admin only, as it should be
/:cl:
