### PR TITLE
Replaces sci flashes with synthflashes on all maps

### DIFF
--- a/_maps/map_files/Beat!Delta/Beat!Delta.dmm
+++ b/_maps/map_files/Beat!Delta/Beat!Delta.dmm
@@ -82793,7 +82793,6 @@
 "cXw" = (
 /obj/structure/table,
 /obj/item/gps,
-/obj/item/assembly/flash/handheld,
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
@@ -82801,6 +82800,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/assembly/flash/synthetic,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cXx" = (
@@ -98224,6 +98224,12 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dAK" = (
@@ -99012,8 +99018,6 @@
 /obj/item/bodypart/l_arm/robot{
 	pixel_x = -3
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
 	pixel_x = -38;
@@ -99022,10 +99026,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)

--- a/_maps/map_files/Beat!Donut/Beat!Donut.dmm
+++ b/_maps/map_files/Beat!Donut/Beat!Donut.dmm
@@ -25743,12 +25743,6 @@
 	amount = 10
 	},
 /obj/item/stack/cable_coil,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -25759,6 +25753,12 @@
 	pixel_x = 30;
 	receive_ore_updates = 1
 	},
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bkQ" = (

--- a/_maps/map_files/Beat!Meta/Beat!Meta.dmm
+++ b/_maps/map_files/Beat!Meta/Beat!Meta.dmm
@@ -60526,17 +60526,17 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/machinery/status_display/ai{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cEp" = (

--- a/_maps/map_files/Beat!Pubby/Beat!Pubby.dmm
+++ b/_maps/map_files/Beat!Pubby/Beat!Pubby.dmm
@@ -25292,17 +25292,17 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 23
 	},
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
+/obj/item/assembly/flash/synthetic,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bnT" = (


### PR DESCRIPTION
[Guidelines]: # (Be sure that your PR follows our guidelines, such as modularization and comment standards. You can read more about the subject here: https://github.com/HippieStation/HippieStation/blob/master/hippiestation/README.md )
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Changelog
:cl: Nopm
tweak: Replaced sci flashes with synthflashes on the maps that still had them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
Because sci flashes were replaced with synthflashes on Box and Kilo, so this changes that for all maps.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
