### PR TITLE
Map rotation

### DIFF
--- a/beatstation/code/controllers/subsystem/vote.dm
+++ b/beatstation/code/controllers/subsystem/vote.dm
@@ -1,2 +1,359 @@
 /datum/controller/subsystem/vote/proc/autotransfer()
 	initiate_vote("crew_transfer","the server")
+
+/datum/controller/subsystem/vote/proc/get_result()
+	//get the highest number of votes
+	var/greatest_votes = 0
+	var/total_votes = 0
+	for(var/option in choices)
+		var/votes = choices[option]
+		total_votes += votes
+		if(votes > greatest_votes)
+			greatest_votes = votes
+	//default-vote for everyone who didn't vote
+	if(!CONFIG_GET(flag/default_no_vote) && choices.len)
+		var/list/non_voters = GLOB.directory.Copy()
+		non_voters -= voted
+		for (var/non_voter_ckey in non_voters)
+			var/client/C = non_voters[non_voter_ckey]
+			if (!C || C.is_afk())
+				non_voters -= non_voter_ckey
+		if(non_voters.len > 0)
+			if(mode == "restart")
+				choices["Continue Playing"] += non_voters.len
+				if(choices["Continue Playing"] >= greatest_votes)
+					greatest_votes = choices["Continue Playing"]
+			else if(mode == "gamemode")
+				if(GLOB.master_mode in choices)
+					choices[GLOB.master_mode] += non_voters.len
+					if(choices[GLOB.master_mode] >= greatest_votes)
+						greatest_votes = choices[GLOB.master_mode]
+			else if(mode == "map")
+				for (var/non_voter_ckey in non_voters)
+					var/client/C = non_voters[non_voter_ckey]
+					if(C.prefs.preferred_map)
+						if(choices[C.prefs.preferred_map]) //No votes if the map isnt in the vote.
+							var/preferred_map = C.prefs.preferred_map
+							choices[preferred_map] += 1
+							greatest_votes = max(greatest_votes, choices[preferred_map])
+					else if(config.defaultmap)
+						if(choices[config.defaultmap]) //No votes if the map isnt in the vote.
+							var/default_map = config.defaultmap.map_name
+							choices[default_map] += 1
+							greatest_votes = max(greatest_votes, choices[default_map])
+			else if(mode == "crew_transfer") // beat start
+				if(choices["Initiate Crew Transfer"] >= greatest_votes)
+					greatest_votes = choices["Initiate Crew Transfer"] // beat end
+	//get all options with that many votes and return them in a list
+	. = list()
+	if(greatest_votes)
+		for(var/option in choices)
+			if(choices[option] == greatest_votes)
+				. += option
+	return .
+
+/datum/controller/subsystem/vote/proc/announce_result()
+	var/list/winners = get_result()
+	var/text
+	if(winners.len > 0)
+		if(question)
+			text += "<b>[question]</b>"
+		else
+			text += "<b>[capitalize(mode)] Vote</b>"
+		for(var/i=1,i<=choices.len,i++)
+			var/votes = choices[choices[i]]
+			if(!votes)
+				votes = 0
+			text += "\n<b>[choices[i]]:</b> [votes]"
+		if(mode != "custom")
+			if(winners.len > 1)
+				text = "\n<b>Vote Tied Between:</b>"
+				for(var/option in winners)
+					text += "\n\t[option]"
+			. = pick(winners)
+			text += "\n<b>Vote Result: [.]</b>"
+		else
+			text += "\n<b>Did not vote:</b> [GLOB.clients.len-voted.len]"
+	else
+		text += "<b>Vote Result: Inconclusive - No Votes!</b>"
+	log_vote(text)
+	remove_action_buttons()
+	to_chat(world, "\n<font color='purple'>[text]</font>")
+	return .
+
+/datum/controller/subsystem/vote/proc/result()
+	. = announce_result()
+	var/restart = FALSE
+	var/crewtransfer = FALSE // beat
+	if(.)
+		switch(mode)
+			if("restart")
+				if(. == "Restart Round")
+					restart = TRUE
+			if("gamemode")
+				if(GLOB.master_mode != .)
+					SSticker.save_mode(.)
+					if(SSticker.HasRoundStarted())
+						restart = TRUE
+					else
+						GLOB.master_mode = .
+			if("map")
+				SSmapping.changemap(global.config.maplist[.])
+				SSmapping.map_voted = TRUE
+			if("crew_transfer") // beat start
+				if(. == "Initiate Crew Transfer")
+					crewtransfer = TRUE // beat end
+	if(restart)
+		var/active_admins = FALSE
+		for(var/client/C in GLOB.admins)
+			if(!C.is_afk() && check_rights_for(C, R_SERVER))
+				active_admins = TRUE
+				break
+		if(!active_admins)
+			SSticker.Reboot("Restart vote successful.", "restart vote")
+		else
+			to_chat(world, "<span style='boldannounce'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
+			message_admins("A restart vote has passed, but there are active admins on with +server, so it has been canceled. If you wish, you may restart the server.")
+	if(crewtransfer) // beat start
+		var/shuttle_timer = SSshuttle.emergency.timeLeft()
+		if(shuttle_timer >= 300 || (SSshuttle.emergency.mode != SHUTTLE_CALL && SSshuttle.emergency.mode != SHUTTLE_DOCKED && SSshuttle.emergency.mode != SHUTTLE_ESCAPE))
+			if(SSshuttle.emergency.mode == SHUTTLE_CALL && shuttle_timer >= 300)
+				SSshuttle.emergencyNoRecall = TRUE
+				SSshuttle.emergency.setTimer(6000)
+				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes due to crew transfer.")
+			else if(SSshuttle.emergency.mode != SHUTTLE_CALL)
+				SSshuttle.emergency.request(reason = " Automatic Crew Transfer", override_timer = 6000)
+				SSshuttle.emergencyNoRecall = TRUE
+			message_admins("The emergency shuttle has been force-called due to a successful crew transfer vote.")
+		else
+			to_chat(world, "<span style='boldannounce'>Notice: The crew transfer vote has failed because the shuttle has already been called.</span>") // beat end
+
+	return .
+
+/datum/controller/subsystem/vote/proc/submit_vote(vote)
+	if(mode)
+		if(CONFIG_GET(flag/no_dead_vote) && usr.stat == DEAD && !usr.client.holder)
+			return FALSE
+		if(!(usr.ckey in voted))
+			if(vote && 1<=vote && vote<=choices.len)
+				voted += usr.ckey
+				choices[choices[vote]]++	//check this
+				return vote
+	return FALSE
+
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key)
+	var/admin = FALSE
+	var/ckey = ckey(initiator_key)
+	if(GLOB.admin_datums[ckey])
+		admin = TRUE
+
+	if(!mode)
+		if(started_time)
+			var/next_allowed_time = (started_time + CONFIG_GET(number/vote_delay))
+			if(mode)
+				to_chat(usr, "<span class='warning'>There is already a vote in progress! please wait for it to finish.</span>")
+				return FALSE
+
+			if(next_allowed_time > world.time && !admin)
+				to_chat(usr, "<span class='warning'>A vote was initiated recently, you must wait [DisplayTimeText(next_allowed_time-world.time)] before a new vote can be started!</span>")
+				return FALSE
+
+		reset()
+		switch(vote_type)
+			if("restart")
+				choices.Add("Restart Round","Continue Playing")
+			if("gamemode")
+				choices.Add(config.votable_modes)
+			if("crew_transfer") // beat start
+				question = "End the shift?"
+				choices.Add("Initiate Crew Transfer","Continue The Round") // beat end
+			if("map")
+				if(!admin && SSmapping.map_voted)
+					to_chat(usr, "<span class='warning'>The next map has already been selected.</span>")
+					return FALSE
+				for(var/map in config.maplist)
+					var/datum/map_config/VM = config.maplist[map]
+					if(!VM.votable || (VM.map_name in SSpersistence.blocked_maps))
+						continue
+					choices.Add(VM.map_name)
+			if("custom")
+				question = stripped_input(usr,"What is the vote for?")
+				if(!question)
+					return FALSE
+				for(var/i=1,i<=10,i++)
+					var/option = capitalize(stripped_input(usr,"Please enter an option or hit cancel to finish"))
+					if(!option || mode || !usr.client)
+						break
+					choices.Add(option)
+			else
+				return FALSE
+		mode = vote_type
+		initiator = initiator_key
+		started_time = world.time
+		var/text = "[capitalize(mode)] vote started by [initiator]."
+		if(mode == "custom")
+			text += "\n[question]"
+		log_vote(text)
+		var/vp = CONFIG_GET(number/vote_period)
+		to_chat(world, "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>")
+		if(vote_type == "crew_transfer") // beat start
+			SEND_SOUND(world, sound('beatstation/sound/ai/alarm4.ogg'))
+		else
+			SEND_SOUND(world, sound('sound/ai/attention.ogg')) // beat end
+		time_remaining = round(vp/10)
+		for(var/c in GLOB.clients)
+			var/client/C = c
+			var/datum/action/vote/V = new
+			if(question)
+				V.name = "Vote: [question]"
+			C.player_details.player_actions += V
+			V.Grant(C.mob)
+			generated_actions += V
+		return TRUE
+	return FALSE
+
+/datum/controller/subsystem/vote/proc/interface(client/C)
+	if(!C)
+		return
+	var/admin = FALSE
+	var/trialmin = FALSE
+	if(C.holder)
+		admin = TRUE
+		if(check_rights_for(C, R_ADMIN))
+			trialmin = TRUE
+	voting |= C
+
+	if(mode)
+		if(question)
+			. += "<h2>Vote: '[question]'</h2>"
+		else
+			. += "<h2>Vote: [capitalize(mode)]</h2>"
+		. += "Time Left: [time_remaining] s<hr><ul>"
+		for(var/i=1,i<=choices.len,i++)
+			var/votes = choices[choices[i]]
+			if(!votes)
+				votes = 0
+			. += "<li><a href='?src=[REF(src)];vote=[i]'>[choices[i]]</a> ([votes] votes)</li>"
+		. += "</ul><hr>"
+		if(admin)
+			. += "(<a href='?src=[REF(src)];vote=cancel'>Cancel Vote</a>) "
+	else
+		. += "<h2>Start a vote:</h2><hr><ul><li>"
+		//restart
+		var/avr = CONFIG_GET(flag/allow_vote_restart)
+		if(trialmin || avr)
+			. += "<a href='?src=[REF(src)];vote=restart'>Restart</a>"
+		else
+			. += "<font color='grey'>Restart (Disallowed)</font>"
+		if(trialmin)
+			. += "\t(<a href='?src=[REF(src)];vote=toggle_restart'>[avr ? "Allowed" : "Disallowed"]</a>)"
+		. += "</li><li>"
+		//gamemode
+		var/avm = CONFIG_GET(flag/allow_vote_mode)
+		if(trialmin || avm)
+			. += "<a href='?src=[REF(src)];vote=gamemode'>GameMode</a>"
+		else
+			. += "<font color='grey'>GameMode (Disallowed)</font>"
+		if(trialmin)
+			. += "\t(<a href='?src=[REF(src)];vote=toggle_gamemode'>[avm ? "Allowed" : "Disallowed"]</a>)"
+
+		. += "</li>"
+		//map
+		var/avmap = CONFIG_GET(flag/allow_vote_map)
+		if(trialmin || avmap)
+			. += "<a href='?src=[REF(src)];vote=map'>Map</a>"
+		else
+			. += "<font color='grey'>Map (Disallowed)</font>"
+		if(trialmin)
+			. += "\t(<a href='?src=[REF(src)];vote=toggle_map'>[avmap ? "Allowed" : "Disallowed"]</a>)"
+
+		. += "</li>"
+		//custom
+		if(trialmin)
+			. += "<li><a href='?src=[REF(src)];vote=custom'>Custom</a></li>"
+		. += "</ul><hr>"
+	. += "<a href='?src=[REF(src)];vote=close' style='position:absolute;right:50px'>Close</a>"
+	return .
+
+
+/datum/controller/subsystem/vote/Topic(href,href_list[],hsrc)
+	if(!usr || !usr.client)
+		return	//not necessary but meh...just in-case somebody does something stupid
+
+	var/trialmin = FALSE
+	if(usr.client.holder)
+		if(check_rights_for(usr.client, R_ADMIN))
+			trialmin = TRUE
+
+	switch(href_list["vote"])
+		if("close")
+			voting -= usr.client
+			usr << browse(null, "window=vote")
+			return
+		if("cancel")
+			if(usr.client.holder)
+				reset()
+		if("toggle_restart")
+			if(usr.client.holder && trialmin)
+				CONFIG_SET(flag/allow_vote_restart, !CONFIG_GET(flag/allow_vote_restart))
+		if("toggle_gamemode")
+			if(usr.client.holder && trialmin)
+				CONFIG_SET(flag/allow_vote_mode, !CONFIG_GET(flag/allow_vote_mode))
+		if("toggle_map")
+			if(usr.client.holder && trialmin)
+				CONFIG_SET(flag/allow_vote_map, !CONFIG_GET(flag/allow_vote_map))
+		if("restart")
+			if(CONFIG_GET(flag/allow_vote_restart) || usr.client.holder)
+				initiate_vote("restart",usr.key)
+		if("gamemode")
+			if(CONFIG_GET(flag/allow_vote_mode) || usr.client.holder)
+				initiate_vote("gamemode",usr.key)
+		if("map")
+			if(CONFIG_GET(flag/allow_vote_map) || usr.client.holder)
+				initiate_vote("map",usr.key)
+		if("custom")
+			if(usr.client.holder)
+				initiate_vote("custom",usr.key)
+		else
+			submit_vote(round(text2num(href_list["vote"])))
+	usr.vote()
+
+/datum/controller/subsystem/vote/proc/remove_action_buttons()
+	for(var/v in generated_actions)
+		var/datum/action/vote/V = v
+		if(!QDELETED(V))
+			V.remove_from_client()
+			V.Remove(V.owner)
+	generated_actions = list()
+
+/mob/verb/vote()
+	set category = "OOC"
+	set name = "Vote"
+
+	var/datum/browser/popup = new(src, "vote", "Voting Panel")
+	popup.set_window_options("can_close=0")
+	popup.set_content(SSvote.interface(client))
+	popup.open(FALSE)
+
+/datum/action/vote
+	name = "Vote!"
+	button_icon_state = "vote"
+
+/datum/action/vote/Trigger()
+	if(owner)
+		owner.vote()
+		remove_from_client()
+		Remove(owner)
+
+/datum/action/vote/IsAvailable()
+	return TRUE
+
+/datum/action/vote/proc/remove_from_client()
+	if(!owner)
+		return
+	if(owner.client)
+		owner.client.player_details.player_actions -= src
+	else if(owner.ckey)
+		var/datum/player_details/P = GLOB.player_details[owner.ckey]
+		if(P)
+			P.player_actions -= src

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(ticker)
 	var/queue_delay = 0
 	var/list/queued_players = list()		//used for join queues when the server exceeds the hard population cap
 
-	var/maprotatechecked = 0
+	//var/maprotatechecked = 0 // beat
 
 	var/news_report
 
@@ -194,13 +194,14 @@ SUBSYSTEM_DEF(ticker)
 		if(GAME_STATE_PLAYING)
 			mode.process(wait * 0.1)
 			check_queue()
-			check_maprotate()
+			//check_maprotate() // beat
 
 			if(!roundend_check_paused && mode.check_finished(force_ending) || force_ending)
 				current_state = GAME_STATE_FINISHED
 				toggle_ooc(TRUE) // Turn it on
 				toggle_dooc(TRUE)
 				declare_completion(force_ending)
+				check_maprotate() // beat
 				Master.SetRunLevel(RUNLEVEL_POSTGAME)
 
 
@@ -447,20 +448,13 @@ SUBSYSTEM_DEF(ticker)
 			queued_players -= next_in_line
 			queue_delay = 0
 
-/datum/controller/subsystem/ticker/proc/check_maprotate()
-	if (!CONFIG_GET(flag/maprotation))
-		return
-	if (SSshuttle.emergency && SSshuttle.emergency.mode != SHUTTLE_ESCAPE || SSshuttle.canRecall())
-		return
-	if (maprotatechecked)
+/datum/controller/subsystem/ticker/proc/check_maprotate() // beat start -- map voting
+	if(!CONFIG_GET(flag/maprotation))
 		return
 
-	maprotatechecked = 1
-
-	//map rotate chance defaults to 75% of the length of the round (in minutes)
-	if (!prob((world.time/600)*CONFIG_GET(number/maprotatechancedelta)))
-		return
-	INVOKE_ASYNC(SSmapping, /datum/controller/subsystem/mapping/.proc/maprotate)
+	/*if(world.time - SSticker.round_start_time < 10 MINUTES) //Not forcing map rotation for very short rounds.
+		return*/
+	INVOKE_ASYNC(SSmapping, /datum/controller/subsystem/mapping/.proc/maprotate) // beat end
 
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
 	return current_state >= GAME_STATE_PLAYING
@@ -492,12 +486,12 @@ SUBSYSTEM_DEF(ticker)
 
 	queue_delay = SSticker.queue_delay
 	queued_players = SSticker.queued_players
-	maprotatechecked = SSticker.maprotatechecked
+	//maprotatechecked = SSticker.maprotatechecked // beat
 	round_start_time = SSticker.round_start_time
 
 	queue_delay = SSticker.queue_delay
 	queued_players = SSticker.queued_players
-	maprotatechecked = SSticker.maprotatechecked
+	//maprotatechecked = SSticker.maprotatechecked // beat
 
 	switch (current_state)
 		if(GAME_STATE_SETTING_UP)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(vote)
 	voted.Cut()
 	voting.Cut()
 	remove_action_buttons()
-
+/* beat start -- map voting
 /* hippie start -- shuttlecall votes
 
 /datum/controller/subsystem/vote/proc/get_result()
@@ -383,4 +383,4 @@ hippie end */
 			P.player_actions -= src
 	else
 		return
-hippie end */
+hippie end */ */ // beat end

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -6,7 +6,7 @@
 		return
 	message_admins("[key_name_admin(usr)] is forcing a random map rotation.")
 	log_admin("[key_name(usr)] is forcing a random map rotation.")
-	SSticker.maprotatechecked = 1
+	//SSticker.maprotatechecked = 1 // beat
 	SSmapping.maprotate()
 
 /client/proc/adminchangemap()
@@ -36,7 +36,7 @@
 	var/chosenmap = input("Choose a map to change to", "Change Map")  as null|anything in maprotatechoices
 	if (!chosenmap)
 		return
-	SSticker.maprotatechecked = 1
+	//SSticker.maprotatechecked = 1 // beat
 	var/datum/map_config/VM = maprotatechoices[chosenmap]
 	message_admins("[key_name_admin(usr)] is changing the map to [VM.map_name]")
 	log_admin("[key_name(usr)] is changing the map to [VM.map_name]")

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -24,9 +24,26 @@ map beat!kilo
 	votable
 endmap
 
+map beat!delta
+	votable
+endmap
+
+map beat!donut
+	votable
+endmap
+
+map beat!meta
+	votable
+endmap
+
+map beat!pubby
+	minplayers 20
+	votable
+endmap
+
 map hippiestation
 	#voteweight 1.5
-	votable
+	#votable
 endmap
 
 map metalake
@@ -40,11 +57,11 @@ endmap
 map metastation
 	minplayers 25
 	#voteweight 0.5
-	votable
+	#votable
 endmap
 
 map pubbystation
-	votable
+	#votable
 endmap
 
 map multiz_debug
@@ -52,12 +69,12 @@ endmap
 
 map deltastation
 	minplayers 50
-	votable
+	#votable
 endmap
 
 map donutstation
 	minplayers 50
-	votable
+	#votable
 endmap
 
 map donutstation

--- a/hippiestation/code/controllers/subsystem/vote.dm
+++ b/hippiestation/code/controllers/subsystem/vote.dm
@@ -1,7 +1,7 @@
 datum/controller/subsystem/vote
 	var/min_restart_time = 60 MINUTES
 	var/min_shuttle_time = 30 MINUTES
-
+/* beat start -- map voting
 /datum/controller/subsystem/vote/proc/get_result()
 	//get the highest number of votes
 	var/greatest_votes = 0
@@ -26,9 +26,6 @@ datum/controller/subsystem/vote
 			if(mode == "shuttlecall")
 				if(choices["Do not call Shuttle"] >= greatest_votes)
 					greatest_votes = choices["Do not call Shuttle"]
-			if(mode == "crew_transfer") // beat start
-				if(choices["Initiate Crew Transfer"] >= greatest_votes)
-					greatest_votes = choices["Initiate Crew Transfer"] // beat end
 			if(mode == "gamemode")
 				if(GLOB.master_mode in choices)
 					choices[GLOB.master_mode] += non_voters.len
@@ -76,9 +73,6 @@ datum/controller/subsystem/vote
 					if(!option || mode || !usr.client)
 						break
 					choices.Add(option)
-			if("crew_transfer") // beat start
-				question = "End the shift?"
-				choices.Add("Initiate Crew Transfer","Continue The Round") // beat end
 			else
 				return 0
 		mode = vote_type
@@ -90,10 +84,7 @@ datum/controller/subsystem/vote
 		log_vote(text)
 		var/vp = CONFIG_GET(number/vote_period)
 		to_chat(world, "\n<font color='purple'><b>[text]</b>\n<div style='font-size: 18px'>Type <b>vote</b> or click <a href='?src=[REF(src)]'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font></div>")
-		if(vote_type == "crew_transfer") // beat start
-			SEND_SOUND(world, sound('beatstation/sound/ai/alarm4.ogg'))
-		else
-			SEND_SOUND(world, sound('sound/ai/attention.ogg')) // beat end
+		SEND_SOUND(world, sound('sound/ai/attention.ogg'))
 		time_remaining = round(vp/10)
 		for(var/c in GLOB.clients)
 			var/client/C = c
@@ -215,7 +206,6 @@ datum/controller/subsystem/vote
 	. = announce_result()
 	var/restart = 0
 	var/shuttlecall = 0
-	var/crewtransfer = 0 // beat
 	if(.)
 		switch(mode)
 			if("restart")
@@ -231,9 +221,6 @@ datum/controller/subsystem/vote
 			if("shuttlecall")
 				if(. == "Call Shuttle")
 					shuttlecall = 1
-			if("crew_transfer") // beat start
-				if(. == "Initiate Crew Transfer")
-					crewtransfer = 1 // beat end
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in GLOB.admins)
@@ -249,29 +236,18 @@ datum/controller/subsystem/vote
 		var/shuttle_timer = SSshuttle.emergency.timeLeft()
 		if(shuttle_timer >= 300 || (SSshuttle.emergency.mode != SHUTTLE_CALL && SSshuttle.emergency.mode != SHUTTLE_DOCKED && SSshuttle.emergency.mode != SHUTTLE_ESCAPE)) // hippie -- fix shuttle votes upping timers to 5 minutes
 			if(SSshuttle.emergency.mode == SHUTTLE_CALL && shuttle_timer >= 300)	//Apparently doing the emergency request twice cancels the call so these check are just in case
-				SSshuttle.emergency.setTimer(3000)
+				SSshuttle.emergency.setTimer(6000)
 				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes.")
 			else if (SSshuttle.emergency.mode != SHUTTLE_CALL)
 				SSshuttle.emergency.request()
-				SSshuttle.emergency.setTimer(3000)
+				SSshuttle.emergency.setTimer(6000)
+				SSshuttle.emergencyNoRecall = TRUE
 				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes.")
 
 			message_admins("The emergency shuttle has been force-called due to a successful shuttle call vote.")
 		else
 			to_chat(world, "<span style='boldannounce'>Notice: The shuttle vote has failed because the shuttle has already been called.</span>")
-	if(crewtransfer) // beat start
-		var/shuttle_timer = SSshuttle.emergency.timeLeft()
-		if(shuttle_timer >= 300 || (SSshuttle.emergency.mode != SHUTTLE_CALL && SSshuttle.emergency.mode != SHUTTLE_DOCKED && SSshuttle.emergency.mode != SHUTTLE_ESCAPE))
-			if(SSshuttle.emergency.mode == SHUTTLE_CALL && shuttle_timer >= 300)
-				SSshuttle.emergencyNoRecall = TRUE
-				SSshuttle.emergency.setTimer(6000)
-				priority_announce("The emergency shuttle will arrive in [SSshuttle.emergency.timeLeft()/60] minutes due to crew transfer.")
-			else if(SSshuttle.emergency.mode != SHUTTLE_CALL)
-				SSshuttle.emergency.request(reason = " Automatic Crew Transfer", override_timer = 6000)
-				SSshuttle.emergencyNoRecall = TRUE
-			message_admins("The emergency shuttle has been force-called due to a successful crew transfer vote.")
-		else
-			to_chat(world, "<span style='boldannounce'>Notice: The crew transfer vote has failed because the shuttle has already been called.</span>") // beat end
+
 	return .
 
 /datum/action/vote/proc/remove_from_client()
@@ -281,4 +257,4 @@ datum/controller/subsystem/vote
 		else if(owner.ckey)
 			var/datum/player_details/P = GLOB.player_details[owner.ckey]
 			if(P)
-				P.player_actions -= src
+				P.player_actions -= src */ // beat end

--- a/hippiestation/code/modules/shuttle/emergency.dm
+++ b/hippiestation/code/modules/shuttle/emergency.dm
@@ -176,7 +176,8 @@
 				mode = SHUTTLE_ESCAPE
 				launch_status = ENDGAME_LAUNCHED
 				setTimer(SSshuttle.emergencyEscapeTime * engine_coeff)
-				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority") // beat
+				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority") // beat -- removes pykoAI
+				SSmapping.mapvote() //If no map vote has been run yet, start one. // beat -- map voting
 
 		if(SHUTTLE_STRANDED)
 			SSshuttle.checkHostileEnvironment()


### PR DESCRIPTION
## Changelog
:cl: Neotw
tweak: Map vote will automatically run as the shuttle leaves, and if no map vote has been run by round end map rotation will trigger
tweak: The last 3 maps are now stored. This means that any map in the last four (including current) rounds are disqualified from map vote and map rotation
/:cl:

## About The Pull Request
Changelog, improves map vote code and also, reverts & modularize subsystem/vote.dm file
ports https://github.com/tgstation/tgstation/pull/48446 https://github.com/tgstation/tgstation/pull/48602

10 hours tested and proven