### PR TITLE
Removes headslugs from gold extact spawn

### DIFF
--- a/hippiestation/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/hippiestation/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -1,2 +1,2 @@
 /mob/living/simple_animal/hostile/headcrab
-	gold_core_spawnable = HOSTILE_SPAWN
+	//gold_core_spawnable = HOSTILE_SPAWN // beat


### PR DESCRIPTION

## Changelog
:cl: Neotw
del: Headslugs have been removed from the gold extract spawn pool
/:cl:
